### PR TITLE
fix: prof and course review section inaccurate metadata

### DIFF
--- a/cypress/e2e/2-reviews/course.cy.js
+++ b/cypress/e2e/2-reviews/course.cy.js
@@ -297,18 +297,18 @@ context("Home", function () {
       // rating section - // TODO make this dynamic
       cy.get(
         "[data-test=rating-average-rating] [data-test=stats-value]",
-      ).should("contain.text", "3.50");
+      ).should("contain.text", "3.73");
       cy.get("[data-test=rating-interesting] [data-test=stats-value]").should(
         "contain.text",
-        "10%",
+        "4%",
       );
       cy.get("[data-test=rating-practical] [data-test=stats-value]").should(
         "contain.text",
-        "10%",
+        "4%",
       );
       cy.get(
         "[data-test=rating-gained-new-skills] [data-test=stats-value]",
-      ).should("contain.text", "10%");
+      ).should("contain.text", "4%");
     });
 
     it("should display accurate review counts", function () {

--- a/cypress/e2e/2-reviews/professor.cy.js
+++ b/cypress/e2e/2-reviews/professor.cy.js
@@ -263,18 +263,18 @@ context("Home", function () {
       // rating section - // TODO make this dynamic
       cy.get(
         "[data-test=rating-average-rating] [data-test=stats-value]",
-      ).should("contain.text", "4.40");
+      ).should("contain.text", "4.25");
       cy.get("[data-test=rating-engaging] [data-test=stats-value]").should(
         "contain.text",
-        "60%",
+        "45%",
       );
       cy.get("[data-test=rating-fair-grading] [data-test=stats-value]").should(
         "contain.text",
-        "50%",
+        "40%",
       );
       cy.get(
         "[data-test=rating-effective-teaching] [data-test=stats-value]",
-      ).should("contain.text", "50%");
+      ).should("contain.text", "40%");
     });
 
     it("should display accurate review counts", function () {

--- a/src/app/(school)/(reviews)/@reviews/course/[code]/opengraph-image.tsx
+++ b/src/app/(school)/(reviews)/@reviews/course/[code]/opengraph-image.tsx
@@ -4,8 +4,7 @@ import React from "react";
 import { BooksIcon } from "@/common/components/CustomIcon";
 import { OgImage } from "@/modules/opengraph/components/OgImage";
 import { api } from "@/common/tools/trpc/server";
-import { toTitleCase } from "@/common/functions";
-import formatPercentage from "@/common/functions/formatPercentage";
+import { toTitleCase, formatPercentage } from "@/common/functions";
 
 export const runtime = "nodejs";
 
@@ -24,7 +23,7 @@ export default async function Image({ params }: { params: { code: string } }) {
   if (!course) return null;
 
   const { averageRating, reviewCount, reviewLabels } =
-    await api.reviews.getMetadataByCourseCode({
+    await api.reviews.getMetadataForCourse({
       code: courseCode,
     });
 

--- a/src/app/(school)/(reviews)/@reviews/professor/[slug]/opengraph-image.tsx
+++ b/src/app/(school)/(reviews)/@reviews/professor/[slug]/opengraph-image.tsx
@@ -4,8 +4,7 @@ import React from "react";
 import { GraduationCapIcon } from "@/common/components/CustomIcon";
 import { api } from "@/common/tools/trpc/server";
 import { OgImage } from "@/modules/opengraph/components/OgImage";
-import formatPercentage from "@/common/functions/formatPercentage";
-import { toTitleCase } from "@/common/functions";
+import { toTitleCase, formatPercentage } from "@/common/functions";
 
 export const runtime = "nodejs";
 
@@ -24,7 +23,7 @@ export default async function Image({ params }: { params: { slug: string } }) {
   if (!prof) return null;
 
   const { averageRating, reviewCount, reviewLabels } =
-    await api.reviews.getMetadataByProfSlug({
+    await api.reviews.getMetadataForProf({
       slug,
     });
   const courseCount = await api.courses.countByProfSlug({ slug });

--- a/src/common/functions/calculateAverage.ts
+++ b/src/common/functions/calculateAverage.ts
@@ -1,4 +1,4 @@
-export default function calculateAverage(array: number[]): number {
+export function calculateAverage(array: number[]): number {
   const total = array.reduce((total: number, item: number) => total + item, 0);
   return total / array.length;
 }

--- a/src/common/functions/formatPercentage.ts
+++ b/src/common/functions/formatPercentage.ts
@@ -1,4 +1,4 @@
-export default function formatPercentage(
+export function formatPercentage(
   amount: number,
   options: Intl.NumberFormatOptions | undefined = undefined,
 ) {

--- a/src/modules/reviews/components/RatingSection/RatingSection.stories.tsx
+++ b/src/modules/reviews/components/RatingSection/RatingSection.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { RatingSection } from "./RatingSection";
-import formatPercentage from "@/common/functions/formatPercentage";
+import { formatPercentage } from "@/common/functions";
 
 const headingRatingItem = { label: "Average Rating", rating: 4.85 };
 const ratingItems = [

--- a/src/modules/reviews/components/ReviewItemLoader/ReviewItemLoader.tsx
+++ b/src/modules/reviews/components/ReviewItemLoader/ReviewItemLoader.tsx
@@ -8,6 +8,7 @@ import {
   ReviewItemSkeleton,
 } from "@/modules/reviews/components/ReviewItem";
 import { AfterclassIcon } from "@/common/components/CustomIcon";
+import { Button } from "@/common/components/Button";
 
 export type ReviewItemLoaderHomeProps = {
   variant: "home";
@@ -90,14 +91,33 @@ export const ReviewItemLoader = (props: ReviewItemLoaderProps) => {
 
   return (
     <>
-      {toShow.map((review) => (
-        <ReviewItem
-          key={review.id}
-          variant={props.variant}
-          review={review}
-          isLocked={!session}
-        />
-      ))}
+      {toShow.length > 0 ? (
+        toShow.map((review) => (
+          <ReviewItem
+            key={review.id}
+            variant={props.variant}
+            review={review}
+            isLocked={!session}
+          />
+        ))
+      ) : (
+        <div className="w-full py-6 text-center text-xs text-text-em-mid md:text-sm">
+          <span>Oh no!</span> Looks like no one has reviewed yet.
+          <br />
+          Help us out by
+          <Button
+            as="a"
+            variant="link"
+            href="/submit"
+            className="mx-1 inline-flex h-fit pb-[1px] text-xs md:h-fit md:p-0 md:text-sm"
+            isResponsive
+            data-umami-event="no-review-cta"
+          >
+            writing one
+          </Button>
+          today ️🙈
+        </div>
+      )}
       {status === "authenticated" && hasNextPage && (
         <InView
           as="div"

--- a/src/modules/reviews/functions/calculateRatingItems.ts
+++ b/src/modules/reviews/functions/calculateRatingItems.ts
@@ -1,6 +1,6 @@
 import { type Review } from "@/modules/reviews/types";
 import { type Labels } from "@prisma/client";
-import formatPercentage from "@/common/functions/formatPercentage";
+import { formatPercentage } from "@/common/functions";
 
 export default function calculateRatingItems(
   reviews: Review[],


### PR DESCRIPTION
closes #347

## Changes

<!--- Describe your changes -->
- use updated metadata query `getMetadataForCourse` & `getMetadataForProf`
- review section now shows a message if there are no reviews
