### PR TITLE
feat(ui): global progress bar to show routing progress

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,6 +18,9 @@ const preview: Preview = {
       },
     },
     layout: "fullscreen",
+    nextjs: {
+      appDirectory: true,
+    },
     options: {
       storySort: {
         method: "alphabetical",

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,7 @@ import "../src/common/styles/globals.scss";
 import { inter, poppins } from "../src/common/fonts";
 import AuthProvider from "../src/common/providers/AuthProvider";
 import TooltipProvider from "../src/common/providers/TooltipProvider";
+import ProgressProvider from "../src/common/providers/ProgressProvider";
 import { SessionContext } from "next-auth/react";
 import { mockAuthStates } from "./auth";
 
@@ -34,24 +35,26 @@ const preview: Preview = {
           {/* @ts-ignore */}
           <SessionContext.Provider value={mockSession}>
             <TooltipProvider>
-              {/* @ts-ignore */}
-              <style global jsx>{`
-                :root {
-                  --font-inter: ${inter.style.fontFamily};
-                  --font-poppins: ${poppins.style.fontFamily};
-                }
-              `}</style>
-              <div
-                style={{
-                  padding: "3rem",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-                className={`bg-bg-base`}
-              >
-                <Story />
-              </div>
+              <ProgressProvider>
+                {/* @ts-ignore */}
+                <style global jsx>{`
+                  :root {
+                    --font-inter: ${inter.style.fontFamily};
+                    --font-poppins: ${poppins.style.fontFamily};
+                  }
+                `}</style>
+                <div
+                  style={{
+                    padding: "3rem",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                  className={`bg-bg-base`}
+                >
+                  <Story />
+                </div>
+              </ProgressProvider>
             </TooltipProvider>
           </SessionContext.Provider>
         </AuthProvider>

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@radix-ui/react-dropdown-menu": "2.1.1",
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-popover": "1.1.1",
+        "@radix-ui/react-progress": "^1.1.1",
         "@radix-ui/react-select": "2.1.1",
         "@radix-ui/react-separator": "1.1.0",
         "@radix-ui/react-toggle-group": "1.1.0",
@@ -609,6 +610,8 @@
     "@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.0", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.0", "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ=="],
 
     "@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.0", "", { "dependencies": { "@radix-ui/react-slot": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw=="],
+
+    "@radix-ui/react-progress": ["@radix-ui/react-progress@1.1.1", "", { "dependencies": { "@radix-ui/react-context": "1.1.1", "@radix-ui/react-primitive": "2.0.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-6diOawA84f/eMxFHcWut0aE1C2kyE9dOyCTQOMRR2C/qPiXz/X0SaiA/RLbapQaXUCmy0/hLMf9meSccD1N0pA=="],
 
     "@radix-ui/react-roving-focus": ["@radix-ui/react-roving-focus@1.1.0", "", { "dependencies": { "@radix-ui/primitive": "1.1.0", "@radix-ui/react-collection": "1.1.0", "@radix-ui/react-compose-refs": "1.1.0", "@radix-ui/react-context": "1.1.0", "@radix-ui/react-direction": "1.1.0", "@radix-ui/react-id": "1.1.0", "@radix-ui/react-primitive": "2.0.0", "@radix-ui/react-use-callback-ref": "1.1.0", "@radix-ui/react-use-controllable-state": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA=="],
 
@@ -2640,6 +2643,10 @@
 
     "@radix-ui/react-label/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.1", "", { "dependencies": { "@radix-ui/react-slot": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg=="],
 
+    "@radix-ui/react-progress/@radix-ui/react-context": ["@radix-ui/react-context@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q=="],
+
+    "@radix-ui/react-progress/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.0.1", "", { "dependencies": { "@radix-ui/react-slot": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg=="],
+
     "@rollup/pluginutils/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
     "@sentry/bundler-plugin-core/glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
@@ -2948,6 +2955,8 @@
 
     "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g=="],
 
+    "@radix-ui/react-progress/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g=="],
+
     "@sentry/bundler-plugin-core/glob/minimatch": ["minimatch@8.0.4", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA=="],
 
     "@sentry/bundler-plugin-core/glob/minipass": ["minipass@4.2.8", "", {}, "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ=="],
@@ -3101,6 +3110,8 @@
     "@pmmmwh/react-refresh-webpack-plugin/schema-utils/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@radix-ui/react-label/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
+
+    "@radix-ui/react-progress/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw=="],
 
     "@sentry/bundler-plugin-core/glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-dropdown-menu": "2.1.1",
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-popover": "1.1.1",
+    "@radix-ui/react-progress": "^1.1.1",
     "@radix-ui/react-select": "2.1.1",
     "@radix-ui/react-separator": "1.1.0",
     "@radix-ui/react-toggle-group": "1.1.0",

--- a/src/app/account/auth/confirm-signup/page.tsx
+++ b/src/app/account/auth/confirm-signup/page.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@/common/components/Button";
+import { ProgressLink } from "@/common/components/Progress";
 import { AuthCard } from "@/modules/auth/components";
 import { notFound } from "next/navigation";
 
@@ -17,15 +17,14 @@ export default function ConfirmSignUp({
         <p>
           Please click on the button below to complete your sign up process.
         </p>
-        <Button
-          as="a"
+        <ProgressLink
           href={confirmationUrl}
           disabled={!confirmationUrl}
           external
           fullWidth
         >
           Confirm Sign Up
-        </Button>
+        </ProgressLink>
       </div>
     </AuthCard>
   );

--- a/src/app/account/auth/verify/page.tsx
+++ b/src/app/account/auth/verify/page.tsx
@@ -97,7 +97,7 @@ export default function Verify({
           <b className="text-text-em-high">Reach out to us via Telegram </b>
           <Button
             as="a"
-            href="https://t.me/AfterClass"
+            href={env.NEXT_PUBLIC_AC_HELPDESK_LINK}
             variant="link"
             className="inline text-xs md:text-base"
             external

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,6 +14,8 @@ import { CSPostHogProvider } from "@/common/providers/analytics/providers";
 import { EdgeConfigProvider } from "@/common/providers/EdgeConfig";
 import { UmamiProvider } from "@/common/providers/Umami";
 import JotaiProvider from "@/common/providers/JotaiProvider";
+import ProgressProvider from "@/common/providers/ProgressProvider";
+import { GlobalProgressBar } from "@/modules/home/components/GlobalProgressBar";
 
 const PostHogPageView = dynamic(
   () => import("@/common/providers/analytics/PostHogPageView"),
@@ -77,13 +79,16 @@ export default function RootLayout({
           <AuthProvider>
             <TRPCReactProvider>
               <TooltipProvider>
-                <EdgeConfigProvider>
-                  <JotaiProvider>
-                    <ThemeProvider>
-                      <CoreLayout>{children}</CoreLayout>
-                    </ThemeProvider>
-                  </JotaiProvider>
-                </EdgeConfigProvider>
+                <ProgressProvider>
+                  <EdgeConfigProvider>
+                    <JotaiProvider>
+                      <ThemeProvider>
+                        <GlobalProgressBar />
+                        <CoreLayout>{children}</CoreLayout>
+                      </ThemeProvider>
+                    </JotaiProvider>
+                  </EdgeConfigProvider>
+                </ProgressProvider>
               </TooltipProvider>
             </TRPCReactProvider>
           </AuthProvider>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,28 +1,27 @@
-import { Button } from "@/common/components/Button";
 import { NoticeCard } from "@/common/components/NoticeCard";
+import { ProgressLink } from "@/common/components/Progress";
+import { env } from "@/env";
 
 export default function NotFound() {
   return (
     <div className="flex justify-center p-6 md:h-full md:items-center md:p-12">
       <NoticeCard title="Not Found" isError>
-        <Button
-          as="a"
+        <ProgressLink
           href="/"
           variant="link"
           className="inline text-[length:inherit]"
         >
           Click here to return to Home.
-        </Button>
+        </ProgressLink>
         <span className="inline">Otherwise, you can get help from us</span>
-        <Button
-          as="a"
-          href="/"
+        <ProgressLink
+          href={env.NEXT_PUBLIC_AC_HELPDESK_LINK}
           variant="link"
           className="inline px-1 text-[length:inherit]"
           external
         >
           @afterclass
-        </Button>
+        </ProgressLink>
         <span className="inline">on Telegram.</span>
       </NoticeCard>
     </div>

--- a/src/common/components/Breadcrumb/BreadcrumbLink/BreadcrumbLink.tsx
+++ b/src/common/components/Breadcrumb/BreadcrumbLink/BreadcrumbLink.tsx
@@ -1,8 +1,11 @@
+"use client";
 import * as React from "react";
 import Link from "next/link";
 import { Slot } from "@radix-ui/react-slot";
 
 import { breadcrumbTheme } from "../Breadcrumb.theme";
+import { useProgress } from "@/common/providers/ProgressProvider";
+import { useRouter } from "next/navigation";
 
 export const BreadcrumbLink = React.forwardRef<
   HTMLAnchorElement,
@@ -11,8 +14,27 @@ export const BreadcrumbLink = React.forwardRef<
     asChild?: boolean;
   }
 >(({ asChild, className, ...props }, ref) => {
-  const Comp = asChild ? Slot : Link;
+  const progress = useProgress();
+  const router = useRouter();
   const { link } = breadcrumbTheme();
-  return <Comp ref={ref} className={link({ className })} {...props} />;
+  const Comp = asChild ? Slot : Link;
+  return (
+    <Comp
+      ref={ref}
+      className={link({ className })}
+      onClick={(e) => {
+        if (props.target === "_blank") return;
+
+        e.preventDefault();
+        progress.start();
+
+        React.startTransition(() => {
+          router.push(props.href);
+          progress.done();
+        });
+      }}
+      {...props}
+    />
+  );
 });
 BreadcrumbLink.displayName = "BreadcrumbLink";

--- a/src/common/components/CoreLayout/CoreLayoutHeader/CoreLayoutHeader.tsx
+++ b/src/common/components/CoreLayout/CoreLayoutHeader/CoreLayoutHeader.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/common/components/Button";
 import { ThemeToggle } from "@/common/components/ThemeToggle";
 import { AfterclassIcon, SearchIcon } from "@/common/components/CustomIcon";
 import { SearchCmdk } from "@/modules/search/components/SearchCmdk";
+import { ProgressLink } from "@/common/components/Progress";
 
 export const CoreLayoutHeader = async () => {
   const session = await auth();
@@ -43,14 +44,13 @@ export const CoreLayoutHeader = async () => {
               </div>
             </>
           ) : (
-            <Button
-              as="a"
+            <ProgressLink
               variant="secondary"
               href="/account/auth/login"
               data-test="login"
             >
               Login
-            </Button>
+            </ProgressLink>
           )}
           <ThemeToggle />
         </div>

--- a/src/common/components/CtaCard/CtaCard.tsx
+++ b/src/common/components/CtaCard/CtaCard.tsx
@@ -30,7 +30,7 @@ export const CtaCard = ({
   };
 
   return (
-    <ProgressLink as="a" className={button()} asChild {...props}>
+    <ProgressLink className={button()} asChild {...props}>
       <div className={ctaWrapper()}>
         {renderIcon(iconLeft)}
         <span className={cta()}>{ctaText}</span>

--- a/src/common/components/CtaCard/CtaCard.tsx
+++ b/src/common/components/CtaCard/CtaCard.tsx
@@ -5,12 +5,10 @@ import {
   cloneElement,
 } from "react";
 
-import {
-  Button,
-  type ButtonLinkOrAnchorProps,
-} from "@/common/components/Button";
+import { type ButtonLinkOrAnchorProps } from "@/common/components/Button";
 
 import { type CtaCardVariants, ctaCardTheme } from "./CtaCard.theme";
+import { ProgressLink } from "@/common/components/Progress";
 
 export type CtaCardProps = CtaCardVariants &
   ButtonLinkOrAnchorProps & {
@@ -32,12 +30,12 @@ export const CtaCard = ({
   };
 
   return (
-    <Button as="a" className={button()} asChild {...props}>
+    <ProgressLink as="a" className={button()} asChild {...props}>
       <div className={ctaWrapper()}>
         {renderIcon(iconLeft)}
         <span className={cta()}>{ctaText}</span>
       </div>
       {renderIcon(iconRight)}
-    </Button>
+    </ProgressLink>
   );
 };

--- a/src/common/components/LockCtaOverlay/LockCtaOverlay.tsx
+++ b/src/common/components/LockCtaOverlay/LockCtaOverlay.tsx
@@ -8,6 +8,7 @@ import {
   lockCtaOverlayTheme,
   type LockCtaOverlayVariants,
 } from "./LockCtaOverlay.theme";
+import { ProgressLink } from "@/common/components/Progress";
 
 const ctaTextMap = {
   rating: "to see rating",
@@ -31,13 +32,12 @@ export const LockCtaOverlay = ({
   return (
     <>
       <div className={overlay()}></div>
-      <Button
-        className={wrapper()}
-        as="a"
+      <ProgressLink
         href={{
           pathname: "/account/auth/login",
           query: { callbackUrl: pathname },
         }}
+        className={wrapper()}
         variant="ghost"
         asChild
         data-test="lock-cta-overlay"
@@ -47,7 +47,7 @@ export const LockCtaOverlay = ({
           <Button variant="link">Login</Button>
           <span>{ctaTextMap[ctaType]}</span>
         </div>
-      </Button>
+      </ProgressLink>
     </>
   );
 };

--- a/src/common/components/Progress/Progress.stories.tsx
+++ b/src/common/components/Progress/Progress.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Progress } from "./Progress";
+import { useEffect, useState } from "react";
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: "Common/Progress",
+  component: Progress,
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ["autodocs"],
+  // More on argTypes: https://storybook.js.org/docs/api/argtypes
+} satisfies Meta<typeof Progress>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => {
+    const [progress, setProgress] = useState(13);
+
+    useEffect(() => {
+      const timer = setTimeout(() => setProgress(66), 500);
+      return () => clearTimeout(timer);
+    }, []);
+
+    return <Progress value={progress} className="w-[60%]" />;
+  },
+};

--- a/src/common/components/Progress/Progress.theme.ts
+++ b/src/common/components/Progress/Progress.theme.ts
@@ -1,0 +1,14 @@
+import { tv, type VariantProps } from "tailwind-variants";
+
+export const progressTheme = tv(
+  {
+    slots: {
+      root: [
+        "bg-primary-default/20 relative h-2 w-full overflow-hidden rounded-full",
+      ],
+      indicator: ["bg-primary-default h-full w-full flex-1 transition-all"],
+    },
+  },
+  { responsiveVariants: true },
+);
+export type ProgressVariants = VariantProps<typeof progressTheme>;

--- a/src/common/components/Progress/Progress.theme.ts
+++ b/src/common/components/Progress/Progress.theme.ts
@@ -4,9 +4,20 @@ export const progressTheme = tv(
   {
     slots: {
       root: [
-        "bg-primary-default/20 relative h-2 w-full overflow-hidden rounded-full",
+        "bg-primary-default/20",
+        "relative",
+        "h-2",
+        "w-full",
+        "overflow-hidden",
+        "rounded-full",
       ],
-      indicator: ["bg-primary-default h-full w-full flex-1 transition-all"],
+      indicator: [
+        "bg-primary-default",
+        "h-full",
+        "w-full",
+        "flex-1",
+        "transition-all",
+      ],
     },
   },
   { responsiveVariants: true },

--- a/src/common/components/Progress/Progress.tsx
+++ b/src/common/components/Progress/Progress.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import * as React from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
+import { progressTheme } from "./Progress.theme";
+import { ProgressLink } from "./ProgressLink";
+
+const Progress = React.forwardRef<
+  React.ElementRef<typeof ProgressPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+>(({ className, value, ...props }, ref) => (
+  <ProgressPrimitive.Root
+    ref={ref}
+    className={progressTheme().root({ className })}
+    {...props}
+  >
+    <ProgressPrimitive.Indicator
+      className={progressTheme().indicator()}
+      style={{ transform: `translateX(-${100 - (value ?? 0)}%)` }}
+    />
+  </ProgressPrimitive.Root>
+));
+Progress.displayName = ProgressPrimitive.Root.displayName;
+
+export { Progress, ProgressLink };

--- a/src/common/components/Progress/ProgressLink/ProgressLink.tsx
+++ b/src/common/components/Progress/ProgressLink/ProgressLink.tsx
@@ -1,0 +1,39 @@
+import { useRouter } from "next/navigation";
+import { startTransition } from "react";
+
+import { useProgress } from "@/common/providers/ProgressProvider";
+import {
+  Button,
+  type ButtonLinkOrAnchorProps,
+} from "@/common/components/Button";
+
+export function ProgressLink({
+  href,
+  children,
+  ...rest
+}: ButtonLinkOrAnchorProps) {
+  const progress = useProgress();
+  const router = useRouter();
+
+  // eslint-disable-next-line @typescript-eslint/no-base-to-string
+  const _href = typeof href === "string" ? href : href.toString();
+
+  return (
+    <Button
+      as="a"
+      href={_href}
+      onClick={(e) => {
+        e.preventDefault();
+        progress.start();
+
+        startTransition(() => {
+          router.push(_href);
+          progress.done();
+        });
+      }}
+      {...rest}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/src/common/components/Progress/ProgressLink/ProgressLink.tsx
+++ b/src/common/components/Progress/ProgressLink/ProgressLink.tsx
@@ -11,7 +11,7 @@ import {
  * A link component that shows a progress indicator during navigation.
  * Wraps navigation actions with a progress bar to provide visual feedback during page transitions.
  *
- * @see https://buildui.com/posts/global-progress-in-nextjs#why-doesnt-nextjs-expose-router-events
+ * @see https://buildui.com/posts/global-progress-in-nextjs
  *
  * @example
  * // Internal navigation with progress indicator

--- a/src/common/components/Progress/ProgressLink/ProgressLink.tsx
+++ b/src/common/components/Progress/ProgressLink/ProgressLink.tsx
@@ -23,11 +23,17 @@ export function ProgressLink({
       as="a"
       href={_href}
       onClick={(e) => {
+        if (rest.external && rest.target !== "_self") return;
+
         e.preventDefault();
         progress.start();
 
         startTransition(() => {
-          router.push(_href);
+          if (rest.external) {
+            window.location.assign(_href);
+          } else {
+            router.push(_href);
+          }
           progress.done();
         });
       }}

--- a/src/common/components/Progress/ProgressLink/ProgressLink.tsx
+++ b/src/common/components/Progress/ProgressLink/ProgressLink.tsx
@@ -7,6 +7,30 @@ import {
   type ButtonLinkOrAnchorProps,
 } from "@/common/components/Button";
 
+/**
+ * A link component that shows a progress indicator during navigation.
+ * Wraps navigation actions with a progress bar to provide visual feedback during page transitions.
+ *
+ * @see https://buildui.com/posts/global-progress-in-nextjs#why-doesnt-nextjs-expose-router-events
+ *
+ * @example
+ * // Internal navigation with progress indicator
+ * <ProgressLink href="/dashboard">
+ *   Go to Dashboard
+ * </ProgressLink>
+ *
+ * @example
+ * // External link with custom target
+ * <ProgressLink href="https://example.com" external>
+ *   Visit External Site
+ * </ProgressLink>
+ *
+ * @example
+ * // hard navigation
+ * <ProgressLink href="/submit" external target="_self">
+ *   Go to Submission Page (hard navigation)
+ * </ProgressLink>
+ */
 export function ProgressLink({
   href,
   children,

--- a/src/common/components/Progress/ProgressLink/index.ts
+++ b/src/common/components/Progress/ProgressLink/index.ts
@@ -1,0 +1,1 @@
+export * from "./ProgressLink";

--- a/src/common/components/Progress/index.ts
+++ b/src/common/components/Progress/index.ts
@@ -1,0 +1,2 @@
+export * from "./Progress";
+export * from "./Progress.theme";

--- a/src/common/hooks/useTransitionMount.ts
+++ b/src/common/hooks/useTransitionMount.ts
@@ -1,0 +1,115 @@
+import { useEffect, useRef, useState } from "react";
+
+/** State of the transition/progress animation */
+type TransitionState = "initial" | "in-progress" | "completing" | "complete";
+
+/** Return value of the useTransitionMount hook */
+interface TransitionMountReturn {
+  /** Current state of the transition */
+  state: TransitionState;
+  /** Current progress value (0-100) */
+  value: number;
+  /** Starts the transition, moving to "in-progress" state */
+  start: () => void;
+  /** Completes the transition, moving to "completing" state */
+  done: () => void;
+  /** Resets the transition back to "initial" state */
+  reset: () => void;
+}
+
+/**
+ * A hook that manages a transition/progress state with animated values.
+ *
+ * @description
+ * Provides animated transitions through different states with corresponding
+ * numeric values from 0 to 100. Useful for progress bars, loading states,
+ * or any UI element that needs staged transitions.
+ *
+ * @example
+ * ```tsx
+ * function ProgressBar() {
+ *   const { value, state, start, done, reset } = useTransitionMount();
+ *
+ *   return (
+ *     <div>
+ *       <div style={{ width: '100%', backgroundColor: '#eee' }}>
+ *         <div
+ *           style={{
+ *             width: `${value}%`,
+ *             height: '20px',
+ *             backgroundColor: '#007bff',
+ *             transition: 'width 0.3s ease-in-out'
+ *           }}
+ *         />
+ *       </div>
+ *       <div>State: {state}</div>
+ *       <button onClick={start}>Start</button>
+ *       <button onClick={done}>Complete</button>
+ *       <button onClick={reset}>Reset</button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @remarks
+ * Progress simulation varies by current value:
+ * - At 0%: +15
+ * - Below 50%: +1-10 (random)
+ * - Above 50%: +1-5 (random)
+ * Updates every 750ms in "in-progress" state.
+ */
+export function useTransitionMount(): TransitionMountReturn {
+  const [state, setState] = useState<TransitionState>("initial");
+  const [value, setValue] = useState(0);
+  const timeoutRef = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    if (state === "initial") {
+      setValue(0);
+    } else if (state === "completing") {
+      setValue(100);
+    } else if (state === "in-progress") {
+      // Simulate progress
+      timeoutRef.current = setInterval(() => {
+        setValue((prev) => {
+          if (prev >= 99) return prev;
+          if (prev === 0) return prev + 15;
+          if (prev < 50) return prev + rand(1, 10);
+          return prev + rand(1, 5);
+        });
+      }, 750);
+    }
+
+    return () => {
+      if (timeoutRef.current) {
+        clearInterval(timeoutRef.current);
+      }
+    };
+  }, [state]);
+
+  useEffect(() => {
+    if (value === 100) {
+      setState("complete");
+    }
+  }, [value]);
+
+  function reset() {
+    setState("initial");
+  }
+
+  function start() {
+    setState("in-progress");
+  }
+
+  function done() {
+    setState((state) =>
+      state === "initial" || state === "in-progress" ? "completing" : state,
+    );
+  }
+
+  return { state, value, start, done, reset };
+}
+
+function rand(min: number, max: number) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/src/common/providers/ProgressProvider.tsx
+++ b/src/common/providers/ProgressProvider.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { type ReactNode, createContext, useContext } from "react";
+
+import { useTransitionMount } from "@/common/hooks/useTransitionMount";
+
+const ProgressBarContext = createContext<ReturnType<
+  typeof useTransitionMount
+> | null>(null);
+
+export function useProgress() {
+  const progress = useContext(ProgressBarContext);
+
+  if (progress === null) {
+    throw new Error("Need to be inside provider");
+  }
+
+  return progress;
+}
+
+export default function ProgressProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const progress = useTransitionMount();
+
+  return (
+    <ProgressBarContext.Provider value={progress}>
+      {children}
+    </ProgressBarContext.Provider>
+  );
+}

--- a/src/modules/auth/components/ForgotPwdForm.tsx
+++ b/src/modules/auth/components/ForgotPwdForm.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { startTransition } from "react";
 import { useRouter } from "next/navigation";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -10,6 +11,7 @@ import { Button } from "@/common/components/Button";
 import { Form } from "@/common/components/Form";
 import { env } from "@/env";
 import { EnvelopeIcon } from "@/common/components/CustomIcon";
+import { useProgress } from "@/common/providers/ProgressProvider";
 
 import { getUserPlatform } from "../functions";
 import {
@@ -17,9 +19,11 @@ import {
   type ForgotPwdFormInputs,
   forgotPwdFormInputsSchema,
 } from "../types";
+import { ProgressLink } from "@/common/components/Progress";
 
 export const ForgotPwdForm = () => {
   const router = useRouter();
+  const progress = useProgress();
 
   const form = useForm<ForgotPwdFormInputs>({
     resolver: zodResolver(forgotPwdFormInputsSchema),
@@ -41,7 +45,12 @@ export const ForgotPwdForm = () => {
     }
 
     if (result === ForgotPwdFormActionReturnType.USER_ON_V1) {
-      router.push(`/account/auth/signup?email=${email}`);
+      progress.start();
+
+      startTransition(() => {
+        router.push(`/account/auth/signup?email=${email}`);
+        progress.done();
+      });
       return;
     }
 
@@ -54,7 +63,12 @@ export const ForgotPwdForm = () => {
       return;
     }
 
-    router.push(`/account/auth/verify?email=${email}`);
+    progress.start();
+
+    startTransition(() => {
+      router.push(`/account/auth/verify?email=${email}`);
+      progress.done();
+    });
   };
 
   return (
@@ -100,17 +114,16 @@ export const ForgotPwdForm = () => {
             <span className="text-center font-semibold text-text-em-mid">
               {"Don't have an account?"}
             </span>
-            <Button
+            <ProgressLink
+              href="/account/auth/signup"
               type="button"
               variant="link"
-              as="a"
-              href="/account/auth/signup"
               isResponsive
               tabIndex={3}
               data-test="register"
             >
               Create an account
-            </Button>
+            </ProgressLink>
           </div>
         </div>
       </form>

--- a/src/modules/auth/components/LoginForm.tsx
+++ b/src/modules/auth/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
@@ -18,6 +18,8 @@ import {
 } from "@/common/components/CustomIcon";
 import { emailValidationSchema } from "@/common/tools/zod/schemas";
 import useUmami from "@/common/hooks/useUmami";
+import { useProgress } from "@/common/providers/ProgressProvider";
+import { ProgressLink } from "@/common/components/Progress";
 
 const loginFormInputsSchema = z.object({
   email: emailValidationSchema,
@@ -31,6 +33,7 @@ export const LoginForm = () => {
   const searchParams = useSearchParams();
   const [isPwdVisible, setIsPwdVisible] = useState(false);
   const router = useRouter();
+  const progress = useProgress();
   const umami = useUmami();
 
   const form = useForm<LoginFormInputs>({
@@ -91,8 +94,13 @@ export const LoginForm = () => {
     }
 
     umami.identify({ email });
-    router.push(signinResp.url ?? callbackUrl);
-    router.refresh();
+
+    progress.start();
+    startTransition(() => {
+      router.push(signinResp.url ?? callbackUrl);
+      router.refresh();
+      progress.done();
+    });
   };
 
   return (
@@ -129,17 +137,16 @@ export const LoginForm = () => {
             <Form.Item>
               <Form.Label className="flex items-center justify-between">
                 <span>Password</span>
-                <Button
-                  variant="link"
-                  as="a"
+                <ProgressLink
                   href="/account/auth/forgot"
+                  variant="link"
                   isResponsive
                   className="md:text-sm"
                   tabIndex={5}
                   data-test="forget"
                 >
                   Forgot password?
-                </Button>
+                </ProgressLink>
               </Form.Label>
               <Form.Control>
                 <Input
@@ -185,17 +192,16 @@ export const LoginForm = () => {
             <span className="text-center font-semibold text-text-em-mid">
               {"Don't have an account?"}
             </span>
-            <Button
+            <ProgressLink
+              href="/account/auth/signup"
               type="button"
               variant="link"
-              as="a"
-              href="/account/auth/signup"
               isResponsive
               tabIndex={6}
               data-test="register"
             >
               Create an account
-            </Button>
+            </ProgressLink>
           </div>
         </div>
       </form>

--- a/src/modules/auth/components/ResetPasswordForm.tsx
+++ b/src/modules/auth/components/ResetPasswordForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { startTransition, useState } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { useRouter } from "next/navigation";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -16,6 +16,7 @@ import {
   EyeIcon,
   EyeSlashIcon,
 } from "@/common/components/CustomIcon";
+import { useProgress } from "@/common/providers/ProgressProvider";
 
 const resetPwdFormInputsSchema = z.object({
   password: z
@@ -26,6 +27,7 @@ type ResetPwdFormInputs = z.infer<typeof resetPwdFormInputsSchema>;
 
 export const ResetPasswordForm = () => {
   const router = useRouter();
+  const progress = useProgress();
   const [isPwdVisible, setIsPwdVisible] = useState(false);
   const [isSubmitSuccessful, setIsSubmitSuccessful] = useState(false);
   const form = useForm<ResetPwdFormInputs>({
@@ -43,7 +45,12 @@ export const ResetPasswordForm = () => {
       return;
     }
     setIsSubmitSuccessful(true);
-    router.push("/account/auth/login");
+
+    progress.start();
+    startTransition(() => {
+      router.push("/account/auth/login");
+      progress.done();
+    });
   };
 
   return (

--- a/src/modules/auth/components/SignupModalV1User.tsx
+++ b/src/modules/auth/components/SignupModalV1User.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Button } from "@/common/components/Button";
 import { Modal } from "@/common/components/Modal";
+import { ProgressLink } from "@/common/components/Progress";
 import { env } from "@/env";
 
 export const SignupModalV1User = () => (
@@ -16,16 +17,15 @@ export const SignupModalV1User = () => (
             <span className="mr-1">
               It looks like you are trying to reset your password for the
             </span>
-            <Button
-              as="a"
+            <ProgressLink
+              href={env.NEXT_PUBLIC_OLD_SITE_URL}
               variant="link"
               className="inline-flex h-fit p-0 pb-[1px] text-text-em-high underline hover:text-secondary-default md:h-fit md:p-0"
-              href={env.NEXT_PUBLIC_OLD_SITE_URL}
               external
               isResponsive
             >
               old AfterClass website.
-            </Button>
+            </ProgressLink>
           </div>
           <p>
             As we migrate to a new platform, users from the old AfterClass
@@ -50,9 +50,9 @@ export const SignupModalV1User = () => (
         <Modal.Close asChild>
           <Button fullWidth>Create a new account</Button>
         </Modal.Close>
-        <Button fullWidth as="a" variant="tertiary" href="/account/auth/login">
+        <ProgressLink href="/account/auth/login" variant="tertiary" fullWidth>
           Login with old AfterClass account
-        </Button>
+        </ProgressLink>
       </Modal.Footer>
     </Modal.Content>
   </Modal>

--- a/src/modules/home/components/AppSidebar/AppSidebar.tsx
+++ b/src/modules/home/components/AppSidebar/AppSidebar.tsx
@@ -30,6 +30,7 @@ import Link from "next/link";
 import { SearchCmdk } from "@/modules/search/components/SearchCmdk";
 import { usePathname } from "next/navigation";
 import { useIsMobile } from "@/common/hooks";
+import { ProgressLink } from "@/common/components/Progress";
 
 type SidebarItemType = {
   label: string;
@@ -153,8 +154,7 @@ export const AppSidebar = () => {
                         : pathname?.startsWith(item.href) // pathname is null in storybook context
                     }
                   >
-                    <Button
-                      as="a"
+                    <ProgressLink
                       variant="ghost"
                       href={item.href}
                       iconLeft={item.icon}
@@ -163,7 +163,7 @@ export const AppSidebar = () => {
                       data-test={`sidebar-${sidebarItemName(item.label)}`}
                     >
                       {item.label}
-                    </Button>
+                    </ProgressLink>
                   </SidebarMenuButton>
                 </SidebarMenuItem>
               ))}
@@ -189,8 +189,7 @@ export const AppSidebar = () => {
                               : pathname?.startsWith(item.href) // pathname is null in storybook context
                           }
                         >
-                          <Button
-                            as="a"
+                          <ProgressLink
                             variant="ghost"
                             href={item.href}
                             target={
@@ -206,7 +205,7 @@ export const AppSidebar = () => {
                             data-test={`sidebar-${sidebarItemName(item.label)}`}
                           >
                             {item.label}
-                          </Button>
+                          </ProgressLink>
                         </SidebarMenuButton>
                       </SidebarMenuItem>
                     ),

--- a/src/modules/home/components/AppSidebar/AppSidebar.tsx
+++ b/src/modules/home/components/AppSidebar/AppSidebar.tsx
@@ -24,7 +24,6 @@ import {
   TelegramIcon,
 } from "@/common/components/CustomIcon";
 import { env } from "@/env";
-import { Button } from "@/common/components/Button";
 import { toTitleCase } from "@/common/functions";
 import Link from "next/link";
 import { SearchCmdk } from "@/modules/search/components/SearchCmdk";

--- a/src/modules/home/components/AppSidebar/AppSidebar.tsx
+++ b/src/modules/home/components/AppSidebar/AppSidebar.tsx
@@ -77,6 +77,7 @@ const SIDEBAR_CATEGORY_ITEMS: SidebarCategoryType = {
       icon: <GithubIcon size={16} />,
       href: env.NEXT_PUBLIC_AC_GITHUB_LINK,
       showMobileOnly: true,
+      external: true,
     },
   ],
   telegram: [
@@ -84,11 +85,13 @@ const SIDEBAR_CATEGORY_ITEMS: SidebarCategoryType = {
       label: "Channel",
       icon: <TelegramIcon size={16} />,
       href: env.NEXT_PUBLIC_AC_CHANNEL_LINK,
+      external: true,
     },
     {
       label: "Helpdesk",
       icon: <HelpDeskIcon size={16} />,
       href: env.NEXT_PUBLIC_AC_HELPDESK_LINK,
+      external: true,
     },
   ],
   site: [
@@ -96,7 +99,6 @@ const SIDEBAR_CATEGORY_ITEMS: SidebarCategoryType = {
       label: "Statistics",
       icon: <StatisticsTableIcon size={16} />,
       href: "/statistics",
-      external: true,
     },
     {
       label: "Themes",

--- a/src/modules/home/components/GlobalProgressBar/GlobalProgressBar.tsx
+++ b/src/modules/home/components/GlobalProgressBar/GlobalProgressBar.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { Progress } from "@/common/components/Progress";
+import { useProgress } from "@/common/providers/ProgressProvider";
+import { useEffect } from "react";
+
+export const GlobalProgressBar = () => {
+  const progress = useProgress();
+  useEffect(() => {
+    if (progress.state === "complete") {
+      setTimeout(() => {
+        progress.reset();
+      }, 500);
+    }
+  }, [progress.state]);
+
+  if (progress.value === 0) return null;
+
+  return (
+    <Progress
+      className="fixed top-0 z-[100] h-1 rounded-none"
+      value={progress.value}
+    />
+  );
+};

--- a/src/modules/home/components/GlobalProgressBar/GlobalProgressBar.tsx
+++ b/src/modules/home/components/GlobalProgressBar/GlobalProgressBar.tsx
@@ -11,6 +11,7 @@ export const GlobalProgressBar = () => {
         progress.reset();
       }, 500);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [progress.state]);
 
   if (progress.value === 0) return null;

--- a/src/modules/home/components/GlobalProgressBar/index.ts
+++ b/src/modules/home/components/GlobalProgressBar/index.ts
@@ -1,0 +1,1 @@
+export * from "./GlobalProgressBar";

--- a/src/modules/reviews/components/InformationSection/InformationCard/InformationCardLoginButton.tsx
+++ b/src/modules/reviews/components/InformationSection/InformationCard/InformationCardLoginButton.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import { Button } from "@/common/components/Button";
 import { usePathname } from "next/navigation";
+import { ProgressLink } from "@/common/components/Progress";
 
 export const InformationCardLoginButton = () => {
   const pathname = usePathname();
   return (
-    <Button
-      as="a"
+    <ProgressLink
       variant="link"
       href={{
         pathname: "/account/auth/login",
@@ -15,6 +14,6 @@ export const InformationCardLoginButton = () => {
       }}
     >
       Login
-    </Button>
+    </ProgressLink>
   );
 };

--- a/src/modules/reviews/components/ReviewItem/ReviewModal/ReviewModal.tsx
+++ b/src/modules/reviews/components/ReviewItem/ReviewModal/ReviewModal.tsx
@@ -9,6 +9,7 @@ import { reviewItemTheme } from "../ReviewItem.theme";
 import { RevieweeGroup } from "../RevieweeGroup";
 import { ReviewLikeButton } from "../ReviewLikeButton";
 import { ReviewCreatedAt } from "../ReviewCreatedAt";
+import { ProgressLink } from "@/common/components/Progress";
 
 export const ReviewModal = ({
   review,
@@ -79,15 +80,14 @@ export const ReviewModal = ({
           {seeMore && (
             <>
               <hr className={seeMoreDivider()} />
-              <Button
-                as="a"
-                variant="link"
+              <ProgressLink
                 href={reviewPath}
+                variant="link"
                 className={seeMoreLink()}
                 isResponsive
               >
                 See more reviews
-              </Button>
+              </ProgressLink>
             </>
           )}
         </Modal.Footer>

--- a/src/modules/reviews/components/ReviewItem/RevieweeGroup/RevieweeCourse.tsx
+++ b/src/modules/reviews/components/ReviewItem/RevieweeGroup/RevieweeCourse.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Tooltip } from "@/common/components/Tooltip";
-import { Button } from "@/common/components/Button";
 import { profileTheme } from "@/common/components/Profile";
+import { ProgressLink } from "@/common/components/Progress";
 
 export const RevieweeCourse = ({
   courseCode,
@@ -14,9 +14,8 @@ export const RevieweeCourse = ({
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <Button
+        <ProgressLink
           variant="link"
-          as="a"
           href={`/course/${courseCode}`}
           className={profileNameClass({
             class: "hover:text-primary-default hover:no-underline",
@@ -25,7 +24,7 @@ export const RevieweeCourse = ({
           data-test="review-course-label"
         >
           {courseCode}
-        </Button>
+        </ProgressLink>
       </Tooltip.Trigger>
       <Tooltip.Content>
         <span>{courseName}</span>

--- a/src/modules/reviews/components/ReviewItem/RevieweeGroup/RevieweeGroup.tsx
+++ b/src/modules/reviews/components/ReviewItem/RevieweeGroup/RevieweeGroup.tsx
@@ -1,10 +1,10 @@
 import { type Review } from "@/modules/reviews/types";
 import { profileTheme } from "@/common/components/Profile";
 import { SchoolIcon } from "@/common/components/CustomIcon";
+import { ProgressLink } from "@/common/components/Progress";
 
 import { RevieweeCourse } from "./RevieweeCourse";
 import { reviewItemTheme, type ReviewItemVariants } from "../ReviewItem.theme";
-import { Button } from "@/common/components/Button";
 
 export type RevieweeGroupProps = ReviewItemVariants & {
   review: Review;
@@ -26,9 +26,8 @@ export const RevieweeGroup = ({ review, variant }: RevieweeGroupProps) => {
     <div className={revieweeGroup()}>
       <SchoolIcon school={review.university} />
       {isShowProf ? (
-        <Button
+        <ProgressLink
           variant="link"
-          as="a"
           href={`/professor/${review.professorSlug}`}
           className={profileNameClass({
             class: "hover:text-primary-default hover:no-underline",
@@ -37,7 +36,7 @@ export const RevieweeGroup = ({ review, variant }: RevieweeGroupProps) => {
           data-test="review-professor-label"
         >
           {review.professorName}
-        </Button>
+        </ProgressLink>
       ) : (
         <RevieweeCourse
           courseCode={review.courseCode}

--- a/src/modules/reviews/components/ReviewItemLoader/ReviewItemLoader.tsx
+++ b/src/modules/reviews/components/ReviewItemLoader/ReviewItemLoader.tsx
@@ -8,7 +8,7 @@ import {
   ReviewItemSkeleton,
 } from "@/modules/reviews/components/ReviewItem";
 import { AfterclassIcon } from "@/common/components/CustomIcon";
-import { Button } from "@/common/components/Button";
+import { ProgressLink } from "@/common/components/Progress";
 
 export type ReviewItemLoaderHomeProps = {
   variant: "home";
@@ -108,16 +108,15 @@ export const ReviewItemLoader = (props: ReviewItemLoaderProps) => {
           <span>Oh no!</span> Looks like no one has reviewed yet.
           <br />
           Help us out by
-          <Button
-            as="a"
-            variant="link"
+          <ProgressLink
             href="/submit"
+            variant="link"
             className="mx-1 inline-flex h-fit pb-[1px] text-xs md:h-fit md:p-0 md:text-sm"
             isResponsive
             data-umami-event="no-review-cta"
           >
             writing one
-          </Button>
+          </ProgressLink>
           today ️🙈
         </div>
       )}

--- a/src/modules/search/components/SearchCmdk/SearchCmdk.tsx
+++ b/src/modules/search/components/SearchCmdk/SearchCmdk.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { type FormEvent, type ReactNode, useEffect, useState } from "react";
-import { Slot } from "@radix-ui/react-slot";
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { useRouter } from "next/navigation";

--- a/src/modules/search/components/SearchCmdk/SearchCmdk.tsx
+++ b/src/modules/search/components/SearchCmdk/SearchCmdk.tsx
@@ -1,18 +1,25 @@
 "use client";
 
-import { type FormEvent, type ReactNode, useEffect, useState } from "react";
+import {
+  type FormEvent,
+  type ReactNode,
+  startTransition,
+  useEffect,
+  useState,
+} from "react";
 import { useAtom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import { useRouter } from "next/navigation";
 
 import { Modal } from "@/common/components/Modal";
-import { Button } from "@/common/components/Button";
 import { SearchIcon } from "@/common/components/CustomIcon";
 import { Input } from "@/common/components/Input";
 import { useEdgeConfigs } from "@/common/hooks";
 
 import { searchCmdkTheme } from "./SearchCmdk.theme";
 import { SearchCmdkModalTrigger } from "./SearchCmdkModalTrigger";
+import { useProgress } from "@/common/providers/ProgressProvider";
+import { ProgressLink } from "@/common/components/Progress";
 
 const hasShownCmdkTooltipAtom = atomWithStorage(
   "hasShownCmdkTooltip",
@@ -35,6 +42,7 @@ export const SearchCmdk = ({
     hasShownCmdkTooltipAtom,
   );
   const router = useRouter();
+  const progress = useProgress();
   const edgeConfig = useEdgeConfigs();
 
   useEffect(() => {
@@ -71,10 +79,15 @@ export const SearchCmdk = ({
 
   const onSearchSubmit = (e: FormEvent) => {
     e.preventDefault();
-    if (searchTerm.length > 0) {
-      setOpen(false);
+    setOpen(false);
+
+    if (searchTerm.length === 0) return;
+
+    progress.start();
+    startTransition(() => {
       router.push(getSearchDestination());
-    }
+      progress.done();
+    });
   };
 
   const { modal, searchIcon, content, contentForm, contentInput, closeBtn } =
@@ -111,18 +124,17 @@ export const SearchCmdk = ({
           />
         </form>
         <Modal.Close asChild>
-          <Button
+          <ProgressLink
+            href={getSearchDestination()}
             variant="primary"
             aria-label="close"
             size="sm"
             className={closeBtn()}
-            as="a"
-            href={getSearchDestination()}
             data-test="search-cmdk-submit"
             type="button"
           >
             Search
-          </Button>
+          </ProgressLink>
         </Modal.Close>
       </Modal.Content>
     </Modal>

--- a/src/modules/search/components/SearchResult/SearchResultItem/SearchResultItem.tsx
+++ b/src/modules/search/components/SearchResult/SearchResultItem/SearchResultItem.tsx
@@ -9,6 +9,7 @@ import Heading from "@/common/components/Heading";
 import { searchResultTheme } from "../SearchResult.theme";
 import { type UniversityAbbreviation } from "@prisma/client";
 import { useSession } from "next-auth/react";
+import { ProgressLink } from "@/common/components/Progress";
 
 export const SearchResultItem = ({
   href,
@@ -35,10 +36,9 @@ export const SearchResultItem = ({
   } = searchResultTheme({ size: { initial: "sm", md: "md" } });
   const { data: session } = useSession();
   return (
-    <Button
-      as="a"
-      className={item()}
+    <ProgressLink
       href={href}
+      className={item()}
       asChild
       data-test="search-result"
     >
@@ -62,6 +62,6 @@ export const SearchResultItem = ({
         </div>
       </div>
       <ChevronRightIcon size={24} className={itemArrow()} />
-    </Button>
+    </ProgressLink>
   );
 };

--- a/src/modules/submit/components/ReviewForm/ReviewForm.tsx
+++ b/src/modules/submit/components/ReviewForm/ReviewForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { startTransition, useEffect, useState, type ReactNode } from "react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { type SubmitHandler, useForm } from "react-hook-form";
 import { useSession } from "next-auth/react";
@@ -16,6 +16,7 @@ import { Form } from "@/common/components/Form";
 import { ReviewableEnum } from "@/modules/submit/types";
 import { reviewFormTheme } from "./ReviewForm.theme";
 import { SubmitButtonGroup } from "../SubmitButtonGroup";
+import { useProgress } from "@/common/providers/ProgressProvider";
 
 export const ReviewForm = ({ children }: { children: ReactNode }) => {
   const formMethods = useForm<ReviewFormInputsSchema>({
@@ -42,6 +43,7 @@ export const ReviewForm = ({ children }: { children: ReactNode }) => {
 
   const { data: session, status } = useSession();
   const router = useRouter();
+  const progress = useProgress();
   const [isLoading, setIsLoading] = useState(status === "loading");
 
   const reviewsMutation = api.reviews.create.useMutation();
@@ -53,7 +55,11 @@ export const ReviewForm = ({ children }: { children: ReactNode }) => {
   useEffect(() => {
     if (reviewsMutation.isSuccess) {
       // TODO: create and highlight reviews after navigating to the review page
-      router.push("/");
+      progress.start();
+      startTransition(() => {
+        router.push("/");
+        progress.done();
+      });
     }
     // router should not be a dependency here
     // https://stackoverflow.com/a/75008835


### PR DESCRIPTION
## Context

<!--- Describe the reason for this change -->
Currently, client side navigation will not show any indication of progress or loading, which can cause users to question if the site is busy routing or has stopped working.

## Changes

<!--- Describe your changes -->
- add a global progress bar that is hidden by default, but will be visible when triggered by navigation
- add `<ProgressLink/>` component to abstract navigation using a polymorphic Button (as Link)


## Implementation Details

<!--- [OPTIONAL], Delete if not used -->
<!---  Describe how you implemented your changes -->
- add shadcn `<Progress/>` component
- update all `<Button/>` with `as='a'` prop to use `<ProgressLink/>` component
- update all `router.push` calls with progress bar triggering transitions


## How to Test

<!--- Describe how to test your changes -->
- vist site, click around to navigate
- should see navigation progress bar
