### PR TITLE
chore(devconfig): ESLint & TSConfig issues

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,6 @@
 /** @type {import("eslint").Linter.Config} */
 const config = {
+  root: true,
   parser: "@typescript-eslint/parser",
   parserOptions: {
     project: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,8 @@
     "**/*.tsx",
     "**/*.cjs",
     "**/*.js",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".eslintrc.cjs"
   ],
   "exclude": ["node_modules", "cypress/**/*.cy.js"]
 }


### PR DESCRIPTION
## Context

<!--- Describe the reason for this change -->
Added some configuration to address ESLint diagnostics issues.

When the contributor use personal config within their system, their settings could possibly leak into project's ESLint, and this may introduce some changes that may conflict with the repository's.

Error from ESLint diagnostics:
```
Diagnostics:
1. eslint: (node:86725) [ESLINT_PERSONAL_CONFIG_SUPPRESS] DeprecationWarning: '~/.eslintrc.*' config files have been deprecated. Please remove it or add 'root:true' to the config files in your projects in order to avoid loading '~/.eslintrc.*' accidentally. (found in "../../../.eslintrc.json")
   (Use `node --trace-deprecation ...` to show where the warning was created)
```

Another errors that was found with ESLint diagnostics:
```
Diagnostics:
1. eslint: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser.
   The file was not found in any of the provided project(s): .eslintrc.cjs
2. eslint: Parsing error: ESLint was configured to run on `<tsconfigRootDir>/.eslintrc.cjs` using `parserOptions.project`: <tsconfigRootDir>/tsconfig.json
   However, that TSConfig does not include this file. Either:
   - Change ESLint's list of included files to not include this file
   - Change that TSConfig to include this file
   - Create a new TSConfig that includes this file and include it in your parserOptions.project
   See the typescript-eslint docs for more info: https://typescript-eslint.io/troubleshooting/typed-linting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```

This just requires simple fix with including `.eslintrc.cjs` into the `tsconfig.json`'s `include`.

## Changes

<!--- Describe your changes -->
* Added `root:true` field to `.eslintrc.cjs`
* Fixed `@typescript-eslint/parser` not able to detect `.eslintrc.cjs`

## How to Test

<!--- Describe how to test your changes -->
ESLint diagnostics output should not complain about the errors anymore.

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->
`.eslintrc.cjs` issues without `root:true`:
![CleanShot 2025-01-15 at 21 16 46](https://github.com/user-attachments/assets/8da4364d-4cb3-4f6d-9610-c6c904b93de0)

`@typescript-eslint/parser` parsing error:
![CleanShot 2025-01-15 at 21 17 41](https://github.com/user-attachments/assets/0d650ff3-7312-446f-a03d-ae66cadb57ab)

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
