### PR TITLE
fix: auth display error on failure & session user to match db user on google auth

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -34,6 +34,8 @@ export const env = createEnv({
         ? process.env.VERCEL_PROJECT_PRODUCTION_URL
         : process.env.VERCEL_URL,
     ),
+    GOOGLE_CLIENT_ID: z.string(),
+    GOOGLE_CLIENT_SECRET: z.string(),
   },
 
   /**
@@ -93,6 +95,8 @@ export const env = createEnv({
     NODE_ENV: process.env.NODE_ENV,
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL ?? process.env.VERCEL_URL,
+    GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET: process.env.GOOGLE_CLIENT_SECRET,
     NEXT_PUBLIC_POSTHOG_KEY: process.env.NEXT_PUBLIC_POSTHOG_KEY,
     NEXT_PUBLIC_POSTHOG_HOST: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     NEXT_PUBLIC_SITE_URL: process.env.NEXT_PUBLIC_SITE_URL,

--- a/src/modules/auth/components/GoogleSignInButton.tsx
+++ b/src/modules/auth/components/GoogleSignInButton.tsx
@@ -57,22 +57,7 @@ export const GoogleSignInButton = ({
       onClick={handleGoogleSignIn}
       tabIndex={4}
       disabled={isLoading}
-      iconLeft={
-        isLoading ? (
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="mr-2 h-4 w-4 animate-spin"
-          >
-            <path d="M21 12a9 9 0 1 1-6.219-8.56" />
-          </svg>
-        ) : undefined
-      }
+      loading={isLoading}
     >
       {children}
     </Button>

--- a/src/modules/auth/components/LoginForm.tsx
+++ b/src/modules/auth/components/LoginForm.tsx
@@ -1,6 +1,5 @@
 "use client";
-
-import { startTransition, useEffect, useState } from "react";
+import { startTransition, useEffect, useState, Fragment } from "react";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { useRouter, useSearchParams } from "next/navigation";
 import { signIn } from "next-auth/react";
@@ -20,7 +19,9 @@ import { emailValidationSchema } from "@/common/tools/zod/schemas";
 import useUmami from "@/common/hooks/useUmami";
 import { useProgress } from "@/common/providers/ProgressProvider";
 import { ProgressLink } from "@/common/components/Progress";
+import { toast } from "@/common/components/Toast";
 import { GoogleSignInButton } from "./GoogleSignInButton";
+import { env } from "@/env";
 
 const loginFormInputsSchema = z.object({
   email: emailValidationSchema,
@@ -47,7 +48,33 @@ export const LoginForm = () => {
   });
 
   useEffect(() => {
-    console.log(window.location.hash);
+    const authJsError = searchParams.get("error");
+    if (authJsError) {
+      toast.warning("Invalid Credentials", {
+        id: authJsError,
+        description: (
+          <>
+            <span>
+              Please try again with an email from the supported domains:
+            </span>
+            <span className="mt-1 flex flex-wrap gap-1">
+              {env.NEXT_PUBLIC_SUPPORTED_SCH_DOMAINS.map((domain, i) => (
+                <Fragment key={i}>
+                  {i > 0 && <span className="mr-1">,</span>}
+                  <span className="relative inline-block before:absolute before:-inset-[2px] before:my-[5px] before:bg-border-primary/15">
+                    <pre className="inline text-text-on-secondary">
+                      {domain}
+                    </pre>
+                  </span>
+                </Fragment>
+              ))}
+            </span>
+          </>
+        ),
+      });
+      return;
+    }
+
     if (!window.location.hash.startsWith("#")) return;
 
     const params = new URLSearchParams(window.location.hash.substring(1));

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -9,7 +9,6 @@ import { type Users } from "@prisma/client";
 import { env } from "@/env";
 import { signInWithEmail } from "../supabase";
 import { db } from "@/server/db";
-import { identifyUser } from "@/server/posthog";
 import randomId from "@/common/functions/randomId";
 import { emailValidationSchema } from "@/common/tools/zod/schemas";
 
@@ -60,16 +59,18 @@ export const authConfig = {
           where: { email: c.data.email },
         });
 
+        const passwordDigest = user?.deprecatedPasswordDigest;
+
         if (
-          user?.deprecatedPasswordDigest &&
-          bcrypt.compareSync(c.data.password, user?.deprecatedPasswordDigest)
+          passwordDigest &&
+          bcrypt.compareSync(c.data.password, passwordDigest)
         ) {
           Sentry.addBreadcrumb({
             category: "auth",
             message: `User ${user.id} logged in with v1 credentials.`,
             level: "info",
           });
-          return await identifyUser(user);
+          return user;
         }
 
         const { data, error } = await signInWithEmail(
@@ -85,49 +86,49 @@ export const authConfig = {
           return null;
         }
 
-        if (data.user) {
-          if (!user) {
-            // user signed into supabase successfully, but user doesn't exist in our database
-            const universities = await db.universities.findMany({
-              include: { domains: true },
-            });
-            const uniOfThisEmail = universities.find((u) =>
-              u.domains.some((d) => emailDomain!.endsWith(d.domain)),
-            );
-
-            if (!uniOfThisEmail) {
-              Sentry.addBreadcrumb({
-                type: "error",
-                category: "auth",
-                message:
-                  `Unexpected email domain '${emailDomain}'.\n` +
-                  "\tUser has signed up with this email but the domain is not associated with any university. " +
-                  "\tPlease check the database for the domain and add it to the universities table if necessary",
-                level: "error",
-              });
-              return null;
-            }
-
-            const newUser = await db.users.create({
-              data: {
-                id: data.user.id,
-                email: data.user.email ?? c.data.email,
-                username: `user_${randomId()}`,
-                isVerified: !!data.user.confirmed_at || false,
-                universityId: uniOfThisEmail.id,
-              },
-            });
-            return await identifyUser(newUser);
-          }
-          // Any object returned will be saved in `user` property of the JWT
-          return await identifyUser(user);
-        } else {
+        if (!data.user) {
           // If you return null then an error will be displayed advising the user to check their details.
           return null;
 
           // You can also Reject this callback with an Error.
           // The user will be sent to the error page with the error message as a query parameter
         }
+
+        if (user) {
+          // Any object returned will be saved in `user` property of the JWT
+          return user;
+        }
+
+        // user signed into supabase successfully, but user doesn't exist in our database
+        const universities = await db.universities.findMany({
+          include: { domains: true },
+        });
+        const uniOfThisEmail = universities.find((u) =>
+          u.domains.some((d) => emailDomain!.endsWith(d.domain)),
+        );
+        if (!uniOfThisEmail) {
+          Sentry.addBreadcrumb({
+            type: "error",
+            category: "auth",
+            message:
+              `Unexpected email domain '${emailDomain}'.\n` +
+              "\tUser has signed up with this email but the domain is not associated with any university. " +
+              "\tPlease check the database for the domain and add it to the universities table if necessary",
+            level: "error",
+          });
+          return null;
+        }
+
+        const newUser = await db.users.create({
+          data: {
+            id: data.user.id,
+            email: data.user.email ?? c.data.email,
+            username: `user_${randomId()}`,
+            isVerified: !!data.user.confirmed_at || false,
+            universityId: uniOfThisEmail.id,
+          },
+        });
+        return newUser;
       },
     }),
     /**
@@ -140,8 +141,9 @@ export const authConfig = {
      * @see https://authjs.dev/getting-started/providers/github
      */
     GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      clientId: env.GOOGLE_CLIENT_ID,
+      clientSecret: env.GOOGLE_CLIENT_SECRET,
+
       async profile(profile: GoogleProfile) {
         console.log("Google Profile:");
         console.dir(profile, { depth: null });
@@ -154,7 +156,7 @@ export const authConfig = {
         });
 
         if (user) {
-          return await identifyUser(user);
+          return user;
         }
 
         const universities = await db.universities.findMany({
@@ -187,14 +189,14 @@ export const authConfig = {
           },
         });
 
-        return identifyUser(newUser);
+        return newUser;
       },
     }),
   ],
   session: { strategy: "jwt" },
   pages: {
     signIn: "/account/auth/login",
-    error: "/account/auth/error", // Error code passed in query string as `?error=`
+    error: "/account/auth/login", // Error code passed in query string as `?error=`
     verifyRequest: "/account/auth/verify", // Used for check email message
   },
   callbacks: {

--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -191,11 +191,9 @@ export const authConfig = {
         // we should be expecting `SessionUser`, not `AdapterUser`
         session.user = token.user as SessionUser;
       }
-
       return session;
     },
-    async signIn({ user, account, profile }) {
-      console.log("User signed in:", user);
+    async signIn({ account, profile }) {
       if (account?.provider === "google") {
         console.log("Google Profile:");
         console.dir(profile, { depth: null });
@@ -204,10 +202,6 @@ export const authConfig = {
 
         if (!googleProfile.email_verified) {
           return false;
-        }
-
-        if (!googleProfile.email_verified) {
-          throw new Error("Email is not verified");
         }
 
         const user = await db.users.findUnique({
@@ -231,10 +225,10 @@ export const authConfig = {
               "\tPlease check the database for the domain and add it to the universities table if necessary",
             level: "error",
           });
-          throw new Error("Unexpected email domain");
+          return false;
         }
 
-        const newUser = await db.users.create({
+        await db.users.create({
           data: {
             email: googleProfile.email,
             username: `user_${randomId()}`,
@@ -243,11 +237,10 @@ export const authConfig = {
             photoUrl: googleProfile.picture,
           },
         });
-        console.log("New user created:", newUser);
-
         return true;
       }
 
+      // For all other providers, by default, return true to allow sign in
       return true;
     },
   },


### PR DESCRIPTION
## Context

<!--- Describe the reason for this change -->
previously we've introduced a change on #383 to allow google oauth

with further inspection, we found 2 main issues:

1. `session.user.id` field (returned when calling `auth()` no longer matches `db.users.id` if auth method is google oauth
2. if any step during auth fails, user is redirected to `/account/auth/error` which doesnt exist


## Changes

<!--- Describe your changes -->
- if auth fails, redirect to `/account/auth/login` with the `?error=` param
- display toast message on login page if auth fails
- load db user on `session.user` during jwt callback if auth method was google auth
   (this is intentionally not done on the session callback as we dont want to initiate a db call everytime a session is checked. see https://authjs.dev/reference/core#session)


