### PR TITLE
feat(flags): use feature flag for review reactions

### DIFF
--- a/src/modules/reviews/components/ReviewItem/ReviewFooter/ReviewFooter.tsx
+++ b/src/modules/reviews/components/ReviewItem/ReviewFooter/ReviewFooter.tsx
@@ -7,22 +7,28 @@ import { ReviewShareButton } from "../ReviewShareButton";
 import { ReviewVoteGroup } from "../ReviewVoteGroup";
 import { ReviewReactionsGroup } from "../ReviewReactionsGroup";
 import { ReviewReactionButton } from "../ReviewReactionButton";
+import { useEdgeConfigs } from "@/common/hooks";
 
 export type ReviewFooterProps = {
   review: Review;
 };
 
 export const ReviewFooter = ({ review }: ReviewFooterProps) => {
+  const ecfg = useEdgeConfigs();
+  const shouldShowReviewReactions = ecfg.enableReviewReactions;
+
   return (
     <div className="space-y-2">
-      <ReviewReactionsGroup reviewId={review.id} />
+      {shouldShowReviewReactions && (
+        <ReviewReactionsGroup reviewId={review.id} />
+      )}
+
       <div className="flex gap-4">
         <ReviewVoteGroup reviewId={review.id} />
-
-        <ReviewReactionButton reviewId={review.id} />
-
+        {shouldShowReviewReactions && (
+          <ReviewReactionButton reviewId={review.id} />
+        )}
         <ReviewShareButton reviewId={review.id} variant="tertiary" size="sm" />
-
         <div
           className={buttonTheme({
             size: "sm",

--- a/src/server/ecfg/config.json
+++ b/src/server/ecfg/config.json
@@ -4,5 +4,5 @@
   "enableReviewEventsTracking": true,
   "enableReviewSort": true,
   "enableReviewFilter": true,
-  "enableReviewReactions": false
+  "enableReviewReactions": true
 }

--- a/src/server/ecfg/config.json
+++ b/src/server/ecfg/config.json
@@ -1,7 +1,7 @@
 {
-  "enableAnnouncementBanner": true,
+  "enableAnnouncementBanner": false,
   "enableCmdkTooltip": true,
   "enableReviewEventsTracking": true,
-  "enableReviewSort": false,
-  "enableReviewFilter": false
+  "enableReviewSort": true,
+  "enableReviewFilter": true
 }

--- a/src/server/ecfg/config.json
+++ b/src/server/ecfg/config.json
@@ -3,5 +3,6 @@
   "enableCmdkTooltip": true,
   "enableReviewEventsTracking": true,
   "enableReviewSort": true,
-  "enableReviewFilter": true
+  "enableReviewFilter": true,
+  "enableReviewReactions": false
 }

--- a/src/server/ecfg/config.ts
+++ b/src/server/ecfg/config.ts
@@ -6,6 +6,7 @@ export const edgeConfigSchema = z.object({
   enableReviewEventsTracking: z.boolean(),
   enableReviewSort: z.boolean(),
   enableReviewFilter: z.boolean(),
+  enableReviewReactions: z.boolean(),
 });
 
 export type EdgeConfig = z.infer<typeof edgeConfigSchema>;


### PR DESCRIPTION
## Context

following up to #405, we'd ideally want to put that new feature behind a feature flag before releasing it to the public internet, to protect against unforseen issues in production, with easy rollbacks

## Changes

<!--- Describe your changes -->
- update `config.json` with the latest deployed ecfg json
- add a new `enableReviewReactions` bool field on ecfg
- hide review reaction functionality if `enableReviewReactions` is `false`
