### PR TITLE
feat: add cache-control headers on request

### DIFF
--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -31,7 +31,10 @@ const handler = (req: NextRequest) =>
       if (allOk && isQuery) {
         return {
           headers: new Headers([
-            ["Cache-Control", `private, max-age=${TTL_SECONDS}`],
+            [
+              "Cache-Control",
+              `private, max-age=${TTL_SECONDS}, must-revalidate`,
+            ],
           ]),
         };
       }


### PR DESCRIPTION
closes #419

## Context

Previously every page change was causing extra requests, to increase performance, initially put a TTL cache of 60 seconds using the Cache-Control HTTP header if in the future 60 seconds is too long then we can revisit the TTL and decide to decrease it

## Changes

set TTL of 60 seconds on all GET requests

## How to Test

browser tools, make multiple requests, shows "cached" on firefox 
tested on chrome and firefox

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
