### PR TITLE
fix(voting): clamp weight values server side

### DIFF
--- a/src/modules/reviews/components/ReviewItem/ReviewVoteGroup/ReviewVoteGroup.tsx
+++ b/src/modules/reviews/components/ReviewItem/ReviewVoteGroup/ReviewVoteGroup.tsx
@@ -80,14 +80,6 @@ export const ReviewVoteGroup = ({ reviewId }: { reviewId: string }) => {
     },
   });
 
-  const handleVote = (weight: number) => {
-    if (!session) return;
-    likeOrUnlike({
-      reviewId,
-      weight,
-    });
-  };
-
   const getUserVoteWeight = useCallback(() => {
     if (getUserVoteQuery.data) {
       return getUserVoteQuery.data.weight;
@@ -102,7 +94,11 @@ export const ReviewVoteGroup = ({ reviewId }: { reviewId: string }) => {
       upvoted={getUserVoteWeight() > 0}
       downvoted={getUserVoteWeight() < 0}
       onVoteChange={({ upvoted, downvoted }) => {
-        handleVote(upvoted ? 1 : downvoted ? -1 : 0);
+        if (!session) return;
+        likeOrUnlike({
+          reviewId,
+          weight: upvoted ? 1 : downvoted ? -1 : 0,
+        });
       }}
     />
   );

--- a/src/server/api/hackVotes/voteOrUnvote/index.ts
+++ b/src/server/api/hackVotes/voteOrUnvote/index.ts
@@ -10,7 +10,7 @@ export const voteOrUnvote = protectedProcedure
   .input(
     z.object({
       hackSubmissionId: z.string(),
-      weight: z.number(),
+      weight: z.union([z.literal(0), z.literal(1)]),
     }),
   )
   .mutation(async ({ input, ctx }) => {

--- a/src/server/api/hackVotes/voteOrUnvote/index.ts
+++ b/src/server/api/hackVotes/voteOrUnvote/index.ts
@@ -2,10 +2,6 @@ import { z } from "zod";
 
 import { protectedProcedure } from "@/server/api/trpc";
 
-function clamp(value: number, min: number, max: number) {
-  return Math.max(min, Math.min(max, value));
-}
-
 export const voteOrUnvote = protectedProcedure
   .input(
     z.object({
@@ -14,7 +10,6 @@ export const voteOrUnvote = protectedProcedure
     }),
   )
   .mutation(async ({ input, ctx }) => {
-    input.weight = clamp(input.weight, 0, 1);
     await ctx.db.hackSubmissionVote.upsert({
       where: {
         hackSubmissionId_voterId: {

--- a/src/server/api/hackVotes/voteOrUnvote/index.ts
+++ b/src/server/api/hackVotes/voteOrUnvote/index.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 import { protectedProcedure } from "@/server/api/trpc";
 
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
 export const voteOrUnvote = protectedProcedure
   .input(
     z.object({
@@ -10,6 +14,7 @@ export const voteOrUnvote = protectedProcedure
     }),
   )
   .mutation(async ({ input, ctx }) => {
+    input.weight = clamp(input.weight, 0, 1);
     await ctx.db.hackSubmissionVote.upsert({
       where: {
         hackSubmissionId_voterId: {

--- a/src/server/api/reviewVotes/voteOrUnvote/index.ts
+++ b/src/server/api/reviewVotes/voteOrUnvote/index.ts
@@ -6,7 +6,7 @@ export const voteOrUnvote = protectedProcedure
   .input(
     z.object({
       reviewId: z.string(),
-      weight: z.number(),
+      weight: z.union([z.literal(-1), z.literal(0), z.literal(1)]),
     }),
   )
   .mutation(


### PR DESCRIPTION
## Context
Directly sending a POST request to `https://www.afterclass.io/api/trpc/hackVotes.voteOrUnvote?batch=1` with appropriate headers allows vote weight to be modified.
<!--- Describe the reason for this change -->

## Changes
Clamped vote weight to 0 or 1 in server side, before db upsert
<!--- Describe your changes -->

## How to Test
Send a cURL request
```bash
curl --location 'http://localhost:3000/api/trpc/hackVotes.voteOrUnvote?batch=1' \
--header 'Content-Type: application/json' \
--header 'Cookie: <COOKIE_HERE>' \
--data '{
    "0": {
        "json": {
            "hackSubmissionId": "c276d7a9-a9d9-4e43-b280-35f0bd3e97a3",
            "weight": 100
        }
    }
}'
```
(I couldn't actually test this locally, but the idea works on prod. I used postman to sync my cookies and it sent the new weights in. To test the clamp function, I updated the weight value in submission.tsx)


Vote should be capped at 1
<!--- Describe how to test your changes -->

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
