### PR TITLE
bugfix(ui): fix home button not redirecting to the base url

### DIFF
--- a/src/modules/home/components/Breadcrumb/Breadcrumb.tsx
+++ b/src/modules/home/components/Breadcrumb/Breadcrumb.tsx
@@ -79,9 +79,11 @@ export const HomeBreadcrumb = (
       <Breadcrumb {...props}>
         <BreadcrumbList>
           <BreadcrumbItem>
-            <BreadcrumbPage className="max-w-80 truncate">
-              {HOME_BREADCRUMB.label}
-            </BreadcrumbPage>
+            {path != "/" && (
+              <BreadcrumbLink href={HOME_BREADCRUMB.href} className="max-w-80 truncate">
+                {HOME_BREADCRUMB.label}
+              </BreadcrumbLink>
+            )}
           </BreadcrumbItem>
         </BreadcrumbList>
       </Breadcrumb>


### PR DESCRIPTION
closes #434

## Context

<!--- Describe the reason for this change -->
Link to issue: [issue #434](https://github.com/afterclass-io/afterclass.io/issues/434)

## Changes
**Behaviour before this change:** Previously, the 'Home' text on the devbar, when clicked, does not navigate the user to the root; `/` path. Also, the 'Home' text shows on all pages

**Behaviour after this change:** 'Home' text now on click, redirects users to the root page. The 'Home' text only shows on non `/` paths.

## How to Test

<!--- Describe how to test your changes -->
**Litmus test:** Home' text on click, redirects users to the root page. The 'Home' text only shows on non `/` paths.

## Preview / Screenshots

<!--- [OPTIONAL], Delete if not used -->
<!--- Add screenshots to help explain your changes -->
<img width="1776" alt="image" src="https://github.com/user-attachments/assets/55d16482-fc1c-4cc2-bcce-756c72985b42" />


## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
