### PR TITLE
feat(ui): debounce review reactions and upvotes

### DIFF
--- a/src/common/components/vote-group.tsx
+++ b/src/common/components/vote-group.tsx
@@ -111,6 +111,7 @@ export const VoteGroup = ({
             notation: "compact",
             compactDisplay: "short",
           }}
+          trend={0}
           value={totalVotes}
           className="font-mono text-sm"
         />

--- a/src/modules/reviews/components/ReviewItem/ReviewVoteGroup/ReviewVoteGroup.tsx
+++ b/src/modules/reviews/components/ReviewItem/ReviewVoteGroup/ReviewVoteGroup.tsx
@@ -1,11 +1,13 @@
 "use client";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { ReviewEventType } from "@prisma/client";
 
 import { api } from "@/common/tools/trpc/react";
 import { useEdgeConfigs } from "@/common/hooks";
 import { VoteGroup } from "@/common/components/vote-group";
+
+import { debounce } from "lodash";
 
 export const ReviewVoteGroup = ({ reviewId }: { reviewId: string }) => {
   const { data: session } = useSession();
@@ -15,46 +17,17 @@ export const ReviewVoteGroup = ({ reviewId }: { reviewId: string }) => {
   const { mutate: track } = api.reviewEvents.track.useMutation();
   const reviewVotesCountQuery = api.reviewVotes.count.useQuery({ reviewId });
   const getUserVoteQuery = api.reviewVotes.getByUser.useQuery({ reviewId });
-  const { mutate: likeOrUnlike } = api.reviewVotes.voteOrUnvote.useMutation({
-    onMutate: async ({ reviewId, weight }) => {
-      // Cancel any outgoing refetches
-      // (so they don't overwrite our optimistic update)
+
+  const mutation = api.reviewVotes.voteOrUnvote.useMutation({
+    onMutate: async ({ reviewId }) => {
+      // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
       await utils.reviewVotes.count.cancel();
       await utils.reviewVotes.getByUser.cancel();
-
       // Snapshot the previous value
       const previousCount = utils.reviewVotes.count.getData({ reviewId });
       const previousUserVote = utils.reviewVotes.getByUser.getData({
         reviewId,
       });
-
-      // Optimistically update to the new value
-      utils.reviewVotes.count.setData(
-        { reviewId },
-        (oldQueryData: number | undefined) => {
-          const prevVoteCount = oldQueryData ?? 0;
-
-          if (previousUserVote?.weight) {
-            if (weight === 0) {
-              // user undid their vote
-              return prevVoteCount - previousUserVote.weight;
-            }
-            // user changed their vote
-            return prevVoteCount + weight * 2;
-          }
-
-          // user voted for the first time
-          return prevVoteCount + weight;
-        },
-      );
-      utils.reviewVotes.getByUser.setData({ reviewId }, (oldQueryData) => {
-        if (!oldQueryData) return null;
-        return {
-          ...oldQueryData,
-          weight,
-        };
-      });
-
       // Return a context object with the snapshotted value
       return { previousCount, previousUserVote };
     },
@@ -79,6 +52,63 @@ export const ReviewVoteGroup = ({ reviewId }: { reviewId: string }) => {
       void utils.reviewVotes.getByUser.invalidate({ reviewId });
     },
   });
+  const likeOrUnlike = mutation.mutate;
+
+  const debouncedLikeOrUnlike = useMemo(
+    () =>
+      debounce((variables: Parameters<typeof likeOrUnlike>[0]) => {
+        likeOrUnlike(variables);
+      }, 300),
+    [likeOrUnlike],
+  ); // 300 ms before likeOrUnlike is called
+
+  const applyOptimisticUpdate = useCallback(
+    (variables: Parameters<typeof likeOrUnlike>[0]) => {
+      const { reviewId, weight } = variables;
+
+      // Snapshot the previous value
+      const previousUserVote = utils.reviewVotes.getByUser.getData({
+        reviewId,
+      });
+
+      // Optimistically update vote count
+      utils.reviewVotes.count.setData(
+        { reviewId },
+        (oldQueryData: number | undefined) => {
+          const prevVoteCount = oldQueryData ?? 0;
+
+          if (previousUserVote?.weight) {
+            if (weight === 0) {
+              // user undid their vote
+              return prevVoteCount - previousUserVote.weight;
+            }
+            // user changed their vote
+            return prevVoteCount + weight * 2;
+          }
+          // user voted for the first time
+          return prevVoteCount + weight;
+        },
+      );
+
+      // Optimistically update user weight
+      utils.reviewVotes.getByUser.setData({ reviewId }, (oldQueryData) => {
+        if (!oldQueryData) return null;
+        return {
+          ...oldQueryData,
+          weight,
+        };
+      });
+    },
+    [utils.reviewVotes.count, utils.reviewVotes.getByUser],
+  );
+
+  const mutateWithDebounce = useCallback(
+    (variables: Parameters<typeof likeOrUnlike>[0]) => {
+      applyOptimisticUpdate(variables); // immediate UI update
+      debouncedLikeOrUnlike(variables); // debounced server mutation
+    },
+    [applyOptimisticUpdate, debouncedLikeOrUnlike],
+  );
 
   const getUserVoteWeight = useCallback(() => {
     if (getUserVoteQuery.data) {
@@ -95,7 +125,7 @@ export const ReviewVoteGroup = ({ reviewId }: { reviewId: string }) => {
       downvoted={getUserVoteWeight() < 0}
       onVoteChange={({ upvoted, downvoted }) => {
         if (!session) return;
-        likeOrUnlike({
+        mutateWithDebounce({
           reviewId,
           weight: upvoted ? 1 : downvoted ? -1 : 0,
         });

--- a/src/server/api/reviewReactions/upsert/index.ts
+++ b/src/server/api/reviewReactions/upsert/index.ts
@@ -14,13 +14,12 @@ export const upsert = protectedProcedure
   .mutation(async ({ input, ctx }) => {
     const reactingUserId = input.userId ?? ctx.session.user.id;
 
+    // workaround for deleteIfExists // https://github.com/prisma/prisma/issues/9460
     if (!input.reaction) {
-      return await ctx.db.reviewReactions.delete({
+      return await ctx.db.reviewReactions.deleteMany({
         where: {
-          reviewId_reactingUserId: {
-            reactingUserId,
-            reviewId: input.reviewId,
-          },
+          reactingUserId,
+          reviewId: input.reviewId,
         },
       });
     }


### PR DESCRIPTION
## Context

Improve user experience in edge cases where user spam clicks reactions or upvotes. Debouncing reduces load on server.
Optimistic update provides instant feedback on users' actions. Strange bug with spamming upvote, number increases more than +1. Eg. start state votes 10, spam upvote can increase number greater than 11.

Minor UX improvement to NumberFlow component with negative votes. Number spins when vote from 0 to -1. Set [trend](https://number-flow.barvian.me/#props) prop in component to fix.

## Changes

Similar logic between vote and reaction debouncing. Reaction uses a custom hook, votes was built-in the component.

## How to Test

Run locally and spam click reactions and upvotes/downvotes and see network tab doesn't flood requests to the BE. UI changes correctly and optimistically.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [ ] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly
