### PR TITLE
feat(db): add warn_inaccuracy field to classes table

### DIFF
--- a/prisma/migrations/20250621171745_add_warn_inaccuracy_field_classes_table/migration.sql
+++ b/prisma/migrations/20250621171745_add_warn_inaccuracy_field_classes_table/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "classes" ADD COLUMN     "warn_inaccuracy" BOOLEAN DEFAULT false;
+ALTER TABLE "classes" ADD COLUMN     "warn_inaccuracy" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/migrations/20250621171745_add_warn_inaccuracy_field_classes_table/migration.sql
+++ b/prisma/migrations/20250621171745_add_warn_inaccuracy_field_classes_table/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "classes" ADD COLUMN     "warn_inaccuracy" BOOLEAN DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -183,6 +183,7 @@ model Classes {
   gradingBasis     GradingBasis? @map("grading_basis")
   courseOutlineUrl String?       @map("course_outline_url")
   bossId           Int           @map("boss_id")
+  warnInaccuracy   Boolean?      @default(false) @map("warn_inaccuracy")
 
   classTimings      ClassTiming[]
   classExamTimings  ClassExamTiming[]

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -183,7 +183,7 @@ model Classes {
   gradingBasis     GradingBasis? @map("grading_basis")
   courseOutlineUrl String?       @map("course_outline_url")
   bossId           Int           @map("boss_id")
-  warnInaccuracy   Boolean?      @default(false) @map("warn_inaccuracy")
+  warnInaccuracy   Boolean       @default(false) @map("warn_inaccuracy")
 
   classTimings      ClassTiming[]
   classExamTimings  ClassExamTiming[]


### PR DESCRIPTION
## Context

BOSS sometimes [lazily list](https://boss.intranet.smu.edu.sg/ClassDetails.aspx?SelectedAcadTerm=2110&SelectedClassNumber=2462) courses (aka classes) that has multiple professors into 1 class schedule, and leave the rest of the class schedules with no professors

the effect being, we'll never know which professor would teach which schedule

![image](https://github.com/user-attachments/assets/ca16101a-cb82-4795-ba70-141add67d526)

to combat this, we will track when we encounter such ambiguity and prompt our users that the data might be inaccurate
