### PR TITLE
chore: create storybook files for BidPredictionCard and ClassCard

### DIFF
--- a/src/modules/bidding/components/BidPredictionCard.stories.tsx
+++ b/src/modules/bidding/components/BidPredictionCard.stories.tsx
@@ -1,0 +1,89 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { BidPredictionCard } from "./BidPredictionCard";
+
+
+type SafetyFactor = { // re-declared as dates are not required
+  beatsPercentage: number;
+  multiplier: number;
+};
+type BidPrediction = {
+  value: number;
+  safetyFactor: SafetyFactor[];
+  uncertainty: number;
+};
+
+
+const minPrediction: BidPrediction = {
+  value: 12000,
+  uncertainty: 2000,
+  safetyFactor: [
+    { beatsPercentage: 10, multiplier: 0.1 },
+    { beatsPercentage: 20, multiplier: 0.2 },
+    { beatsPercentage: 30, multiplier: 0.3 },
+    { beatsPercentage: 40, multiplier: 0.4 },
+    { beatsPercentage: 50, multiplier: 0.5 },
+    { beatsPercentage: 60, multiplier: 0.6 },
+    { beatsPercentage: 70, multiplier: 0.7 },
+    { beatsPercentage: 80, multiplier: 0.8 },
+    { beatsPercentage: 90, multiplier: 0.9 },
+    { beatsPercentage: 100, multiplier: 1 },
+  ],
+};
+
+const medianPrediction = {
+  value: 15000,
+  uncertainty: 2500,
+  safetyFactor: [
+    { beatsPercentage: 10, multiplier: 0.1 },
+    { beatsPercentage: 20, multiplier: 0.2 },
+    { beatsPercentage: 30, multiplier: 0.3 },
+    { beatsPercentage: 40, multiplier: 0.4 },
+    { beatsPercentage: 50, multiplier: 0.5 },
+    { beatsPercentage: 60, multiplier: 0.6 },
+    { beatsPercentage: 70, multiplier: 0.7 },
+    { beatsPercentage: 80, multiplier: 0.8 },
+    { beatsPercentage: 90, multiplier: 0.9 },
+    { beatsPercentage: 100, multiplier: 1 },
+  ],
+};
+
+const meta: Meta<typeof BidPredictionCard> = {
+  title: "Bid Analytics/BidPredictionCard",
+  component: BidPredictionCard,
+  tags: ["autodocs"],
+  args: {
+    courseCode: "CS101",
+    section: "T01",
+    acadTermId: "AY2024/2025 Semester 1",
+    hasBidsProbability: 0.8,
+    confidenceScore: 0.75,
+    minPrediction: minPrediction,
+    medianPrediction: medianPrediction,
+
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+
+export const Default: Story = {};
+
+export const LowConfidence: Story = {
+  args: {
+    confidenceScore: 0.4,
+  },
+};
+
+export const VeryHighConfidence: Story = {
+  args: {
+    confidenceScore: 0.95,
+  },
+};
+
+export const UnlikelyToHaveBids: Story = {
+  args: {
+    hasBidsProbability: 0.2,
+  },
+};

--- a/src/modules/bidding/components/ClassCard.stories.tsx
+++ b/src/modules/bidding/components/ClassCard.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { ClassCard } from "./ClassCard";
+import { ClockIcon, GraduationCapColoredIcon, MemoIcon, PinIcon } from "@/common/components/icons";
+
+const meta: Meta<typeof ClassCard> = {
+  title: "Bid Analytics/ClassCard",
+  component: ClassCard,
+  tags: ["autodocs"],
+  args: {
+    section: "T01",
+    classId: "12345",
+    course: {
+      code: "CS101",
+      name: "Introduction to Computer Science",
+    },
+    professor: {
+      name: "Dr. Jane Doe",
+      slug: "jane-doe",
+    },
+    classTiming: [
+      {
+        dayOfWeek: "MON",
+        startTime: "10:00",
+        endTime: "12:00",
+        venue: "COM1-201",
+      },
+      {
+        dayOfWeek: "WED",
+        startTime: "10:00",
+        endTime: "12:00",
+        venue: "COM1-201",
+      },
+    ],
+    examTiming: [
+      {
+        date: new Date("2025-12-15T00:00:00Z"),
+        dayOfWeek: "MON",
+        startTime: "09:00",
+        endTime: "12:00",
+        venue: "TBA",
+      },
+    ],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+
+export const Default: Story = {};
+
+export const NoProfessor: Story = {
+  args: {
+    professor: null,
+  },
+};
+
+
+export const NoClassTimings: Story = {
+  args: {
+    classTiming: [],
+  },
+};
+
+
+export const NoExamTimings: Story = {
+  args: {
+    examTiming: [],
+  },
+};
+
+
+export const MultipleTimings: Story = {
+  args: {
+    classTiming: [
+      {
+        dayOfWeek: "MON",
+        startTime: "10:00",
+        endTime: "12:00",
+        venue: "COM1-201",
+      },
+      {
+        dayOfWeek: "TUE",
+        startTime: "14:00",
+        endTime: "16:00",
+        venue: "COM1-202",
+      },
+    ],
+    examTiming: [
+      {
+        date: new Date("2025-12-15T00:00:00Z"),
+        dayOfWeek: "MON",
+        startTime: "09:00",
+        endTime: "12:00",
+        venue: "TBA",
+      },
+      {
+        date: new Date("2025-12-22T00:00:00Z"),
+        dayOfWeek: "MON",
+        startTime: "14:00",
+        endTime: "17:00",
+        venue: "COM1-201",
+      },
+    ],
+  },
+};
+
+
+export const MissingExamDetails: Story = {
+  args: {
+    examTiming: [
+      {
+        date: new Date("2025-12-15T00:00:00Z"),
+        dayOfWeek: "MON",
+        // startTime and endTime are missing
+        venue: "TBA",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Context

BidPredictionCard and ClassCard did not have corresponding files for storybook.

## Changes

Added .stories.tsx files for both components

## Implementation Details

Added .stories.tsx files for both components

## How to Test

Components now accessible through storybook under the Bid Analytics section

## Preview / Screenshots
<img width="1317" height="625" alt="classcard storybook" src="https://github.com/user-attachments/assets/32e605cf-306e-4e67-9376-bd244060860a" />
<img width="1110" height="833" alt="BidPredictionCard storybook" src="https://github.com/user-attachments/assets/e71908e2-974d-47c3-b065-9b8011c0d04e" />


## Checklist

- [✅] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [✅] I have tested the changes
- [✅] _(where applicable)_ I have added tests to cover my changes
- [✅] _(where applicable)_ I have updated the documentation accordingly
