### PR TITLE
fix(timetable): use https feed URL in Google Calendar subscribe link

### DIFF
--- a/src/modules/timetable/functions/calendar-links.test.ts
+++ b/src/modules/timetable/functions/calendar-links.test.ts
@@ -22,7 +22,7 @@ describe("buildCalendarLinks", () => {
     const links = buildCalendarLinks("https://afterclass.io", "tok123");
     expect(links.googleSubscribeUrl).toBe(
       "https://calendar.google.com/calendar/r?cid=" +
-        encodeURIComponent("webcal://afterclass.io/api/ical/tok123"),
+        encodeURIComponent("https://afterclass.io/api/ical/tok123"),
     );
     expect(links.appleSubscribeUrl).toBe(
       "webcal://afterclass.io/api/ical/tok123",

--- a/src/modules/timetable/functions/calendar-links.ts
+++ b/src/modules/timetable/functions/calendar-links.ts
@@ -9,7 +9,8 @@ export type CalendarLinks = {
   /** webcal:// URL — opens desktop calendar apps (Apple Calendar, Outlook)
    *  directly. Web calendars generally expect the https `feedUrl` instead. */
   subscribeUrl: string;
-  /** One-step subscribe URLs for the major calendar apps. */
+  /** Google Calendar one-step subscribe — uses the https `feedUrl` in `cid`
+   *  (Google stores the URL verbatim; webcal fails to sync). */
   googleSubscribeUrl: string;
   appleSubscribeUrl: string;
   outlookSubscribeUrl: string;
@@ -18,10 +19,11 @@ export type CalendarLinks = {
 /**
  * Build the feed and subscription URLs for an iCal token.
  *
- * `subscribeUrl` swaps the http(s) scheme for `webcal://`, which calendar
- * apps register as their subscription protocol. The Google / Apple / Outlook
- * one-step URLs reuse it (or the plain `feedUrl`) inside each app's own
- * subscribe flow.
+ * `subscribeUrl` swaps the http(s) scheme for `webcal://`, which Apple
+ * Calendar (and similar desktop apps) register as their subscription protocol.
+ * Google Calendar expects the plain https `feedUrl` in `cid`; passing the
+ * webcal URL causes the subscription to sync empty. Outlook uses the https
+ * `feedUrl` in `url`.
  */
 export function buildCalendarLinks(
   origin: string,
@@ -32,7 +34,7 @@ export function buildCalendarLinks(
   return {
     feedUrl,
     subscribeUrl,
-    googleSubscribeUrl: `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(subscribeUrl)}`,
+    googleSubscribeUrl: `https://calendar.google.com/calendar/r?cid=${encodeURIComponent(feedUrl)}`,
     appleSubscribeUrl: subscribeUrl,
     outlookSubscribeUrl: `https://outlook.live.com/calendar/0/addfromweb?url=${encodeURIComponent(feedUrl)}`,
   };


### PR DESCRIPTION
## Context
When users subscribe to a timetable feed via Google Calendar, passing a `webcal://` scheme in the `cid` query parameter causes Google Calendar to store the subscription URL verbatim without resolving events, resulting in an empty synchronized calendar.

## Changes
Google Calendar stores the cid URL verbatim; passing webcal:// caused subscriptions to sync empty. Switch googleSubscribeUrl to encode the https feedUrl instead and update docs/comments to clarify protocol expectations across Google, Apple and Outlook.

## Implementation Details
* Updated `buildCalendarLinks` in `calendar-links.ts` so that `googleSubscribeUrl` encodes `feedUrl` (`https://...`) instead of `subscribeUrl` (`webcal://...`).
* Updated JSDoc comments on `CalendarLinks` and `buildCalendarLinks` to document expected protocols per client (`https` for Google and Outlook, `webcal` for Apple Calendar and desktop clients).
* Updated unit test assertions in `calendar-links.test.ts` to expect the encoded `https` URL for `googleSubscribeUrl`.

## How to Test
1. Run unit tests to ensure URL builder logic passes:
```bash
pnpm test calendar-links.test.ts
```
2. Generate a timetable subscription link and open the generated `googleSubscribeUrl` in a browser.
3. Confirm Google Calendar successfully imports and populates timetable events instead of creating an empty calendar feed.

## Checklist
* [x] I have read the [[CONTRIBUTING](https://www.google.com/search?q=CONTRIBUTING.md)](https://www.google.com/search?q=CONTRIBUTING.md) document
* [x] I have tested the changes
* [x] *(where applicable)* I have added tests to cover my changes
* [x] *(where applicable)* I have updated the documentation accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Google Calendar subscription links to use the HTTPS feed URL.
  * Preserved the existing subscription link formats for Apple Calendar and Outlook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->