### PR TITLE
fix(security): scope Sentry user context to the request, not the process

### DIFF
--- a/src/server/auth/config.ts
+++ b/src/server/auth/config.ts
@@ -255,15 +255,4 @@ export const authConfig = {
       return true;
     },
   },
-  events: {
-    signIn({ user }) {
-      // strip user object of unwanted sensitive fields before populating to Sentry
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { deprecatedPasswordDigest, ...unsensoredUser } = user as Users;
-      Sentry.getGlobalScope().setUser(unsensoredUser);
-    },
-    signOut() {
-      Sentry.getGlobalScope().setUser(null);
-    },
-  },
 } satisfies NextAuthConfig;

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -2,9 +2,15 @@ import NextAuth from "next-auth";
 import { cache } from "react";
 
 import { authConfig } from "./config";
+import { setSentryUser } from "./sentryUser";
 
 const { auth: uncachedAuth, handlers, signIn, signOut } = NextAuth(authConfig);
 
-const auth = cache(uncachedAuth);
+// Re-derive the Sentry user from *this* request's session on every read.
+const auth = cache(async () => {
+  const session = await uncachedAuth();
+  setSentryUser(session);
+  return session;
+});
 
 export { auth, handlers, signIn, signOut };

--- a/src/server/auth/sentryUser.test.ts
+++ b/src/server/auth/sentryUser.test.ts
@@ -1,0 +1,33 @@
+import * as Sentry from "@sentry/nextjs";
+import { describe, expect, it, vi } from "vitest";
+
+import { setSentryUser } from "./sentryUser";
+
+// Only `setUser` is mocked on purpose: reintroducing `getGlobalScope()` here
+// fails loudly ("not a function") instead of passing silently.
+vi.mock("@sentry/nextjs", () => ({ setUser: vi.fn() }));
+
+describe("setSentryUser", () => {
+  it("sends only id/email/username, dropping the rest of the user row", () => {
+    setSentryUser({
+      user: {
+        id: "u1",
+        email: "amy@smu.edu.sg",
+        username: "amy",
+        deprecatedPasswordDigest: "$2b$10$hunter2",
+        firstName: "Amy",
+      },
+    } as never);
+
+    expect(Sentry.setUser).toHaveBeenCalledWith({
+      id: "u1",
+      email: "amy@smu.edu.sg",
+      username: "amy",
+    });
+  });
+
+  it("clears the user when there is no session", () => {
+    setSentryUser(null);
+    expect(Sentry.setUser).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/server/auth/sentryUser.ts
+++ b/src/server/auth/sentryUser.ts
@@ -1,0 +1,14 @@
+import * as Sentry from "@sentry/nextjs";
+import { type Session } from "next-auth";
+
+/**
+ * Bind the signed-in user to Sentry's isolation scope, which `@sentry/nextjs`
+ * creates fresh per request — unlike the global scope it cannot bleed into
+ * other concurrent requests on the same server process.
+ */
+export const setSentryUser = (session: Session | null) => {
+  const user = session?.user;
+  Sentry.setUser(
+    user ? { id: user.id, email: user.email, username: user.username } : null,
+  );
+};


### PR DESCRIPTION
closes #501

## Context

`events.signIn` / `events.signOut` in `src/server/auth/config.ts` wrote Sentry user
context to the **process-global** scope:

```ts
Sentry.getGlobalScope().setUser(unsensoredUser);
```

The global scope is one object per Node.js process and is merged into every event the
SDK sends. On a shared server instance the last user to sign in was stamped onto errors
and telemetry raised by **every other concurrent user and anonymous request**, until
someone else signed in or out — a cross-tenant identity leak in our observability data.

There was a second, quieter bug in the same block: it only fired on the sign-in request,
so every *subsequent* request relied on that leaked global state to be attributed at all.
The mechanism was both wrong and the only thing making attribution appear to work.

## Changes

- Delete the `events: { signIn, signOut }` block from `src/server/auth/config.ts`.
- Add `src/server/auth/sentryUser.ts` — `setSentryUser(session)`, using the top-level
  `Sentry.setUser()`.
- Call it from the `cache()`-wrapped `auth()` in `src/server/auth/index.ts`, so the user is
  re-derived from *this* request's own session on every read.
- Add `src/server/auth/sentryUser.test.ts`.

## Implementation Details

**Why `Sentry.setUser()` is the fix.** On our pinned `@sentry/core@8.55.0`
(`build/cjs/exports.js`), the top-level export is already isolation-scoped:

```js
function setUser(user) { currentScopes.getIsolationScope().setUser(user); }
```

`next.config.js` wraps the config in `withSentryConfig`, and `SentryHttpInstrumentation`
wraps every incoming request in `withIsolationScope` — so the isolation scope is genuinely
per-request (`AsyncLocalStorage`-backed) and covers RSC renders, not just API routes.

**Why `auth()` is the attachment point.** `src/server/auth/index.ts` is the single
chokepoint every server-side session read goes through — the tRPC context
(`src/server/api/trpc.ts`) plus ~11 RSC call sites. Setting the user there fixes it once
for all callers instead of per call site, and re-derives identity per request rather than
once at sign-in.

This narrows the exported `auth` to its zero-arg (RSC) overload. Verified safe: every call
site calls `auth()` with no arguments, there is no `middleware.ts`, the NextAuth route uses
`handlers`, and nothing references `typeof auth`. `tsc --noEmit` confirms.

### Two deliberate behaviour changes, called out

1. **The Sentry user payload is narrowed** to `{id, email, username}` — previously the whole
   `Users` row minus `deprecatedPasswordDigest`. This is a strict subset of what was already
   being sent and matches Sentry's canonical user shape, but it does reduce triage context
   (`firstName`, `universityId`, `facultyId` no longer reach Sentry). Happy to widen if
   reviewers want those back.
2. **The sign-in callback request itself no longer carries a Sentry user.**
   `/api/auth/callback/...` is served by `handlers`, not `auth()`, so nothing calls
   `setSentryUser` on that one request; the old global write did tag it. Errors inside
   `authorize()` fire *before* `events.signIn` anyway and the existing `addBreadcrumb` calls
   already carry the user id, so the lost window is small — but it is a real reduction in
   diagnostic coverage of the auth callback path. A one-line request-scoped
   `Sentry.setUser()` inside `events.signIn` would restore it if preferred.

## How to Test

1. `bun run test` — 382 tests across 60 files pass, including the two new cases in
   `src/server/auth/sentryUser.test.ts`.
2. `grep -rn "getGlobalScope" src/` returns nothing.
3. The new test mocks **only** `setUser`
   (`vi.mock("@sentry/nextjs", () => ({ setUser: vi.fn() }))`), so reintroducing
   `getGlobalScope()` fails loudly with "not a function" rather than passing silently.
4. Manual (needs a Sentry DSN): sign in as user A, then from a separate private window
   trigger a server-side error as an anonymous visitor. The anonymous event must carry no
   user; user A's own requests must carry user A.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [x] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication session handling to keep error-monitoring user context synchronized with the current session.
  * Cleared monitoring user information when no authenticated session is present.
  * Limited shared user details to relevant identifying information.

* **Tests**
  * Added coverage verifying authenticated and unauthenticated monitoring states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->