### PR TITLE
fix(bidding): stop content hiding under the expanded sidebar (#545)

### DIFF
--- a/cypress/e2e/6-bidding/analytics-layout.cy.ts
+++ b/cypress/e2e/6-bidding/analytics-layout.cy.ts
@@ -1,0 +1,59 @@
+/// <reference types="cypress" />
+
+/**
+ * Bid Analytics layout E2E test (afterclass-io#545)
+ *
+ * The bidding layout sits the main content column next to a CTA rail that is
+ * sized to its own content (`max-w-min` + `text-nowrap`) and so never shrinks.
+ * If the content column cannot shrink either, the row overflows and
+ * `justify-center` spills half of that overflow to the LEFT — off-canvas, where
+ * scrolling cannot reach it and the fixed sidebar covers it.
+ *
+ * Symptom: with the sidebar expanded, the course header card and Historical
+ * Bidding Trend card are clipped on the left ("egotiating…", "storical…").
+ *
+ * Only viewports >= MOBILE_BREAKPOINT (1250, see src/common/hooks/use-mobile.ts)
+ * can reproduce it — below that the sidebar is an overlay Sheet, not a fixed
+ * column, so there is nothing for content to hide under.
+ */
+
+const ANALYTICS_URL =
+  "/bidding/analytics?course=ACCT102&section=G1&classId=seed-ay202627t1-acct102-g1";
+
+context("Bid Analytics: layout", function () {
+  beforeEach(function () {
+    cy.viewport(1280, 800);
+    cy.visit(ANALYTICS_URL);
+    // The Historical Bidding Trend card is what makes the content column wide
+    // (718px min-content vs 299px for the class-info card), and its chart is
+    // client-rendered — measure only once it has mounted, or the assertions
+    // pass for the wrong reason.
+    cy.get("[data-slot=chart]", { timeout: 20000 }).should("be.visible");
+    cy.get("[data-slot=sidebar]").should("have.attr", "data-state", "expanded");
+  });
+
+  it("does not hide content behind the expanded sidebar", function () {
+    cy.get("[data-slot=sidebar-container]").then(($sidebar) => {
+      const sidebarRight = $sidebar[0]!.getBoundingClientRect().right;
+      cy.get("[data-test=bid-analytics-content]").then(($content) => {
+        const contentLeft = $content[0]!.getBoundingClientRect().left;
+        expect(
+          contentLeft,
+          `content left edge (${contentLeft}) must clear the sidebar (${sidebarRight})`,
+        ).to.be.at.least(sidebarRight);
+      });
+    });
+  });
+
+  // Guards `min-w-0` on SidebarInset: without it a wide page stretches the
+  // whole shell past the viewport instead of fitting inside it.
+  it("does not push the page wider than the viewport", function () {
+    cy.document().then((doc) => {
+      const { scrollWidth, clientWidth } = doc.documentElement;
+      expect(
+        scrollWidth,
+        `page scroll width (${scrollWidth}) must not exceed the viewport (${clientWidth})`,
+      ).to.be.at.most(clientWidth);
+    });
+  });
+});

--- a/src/app/(school)/(reviews)/layout.tsx
+++ b/src/app/(school)/(reviews)/layout.tsx
@@ -25,7 +25,7 @@ export default function ReviewLayout({
       {rating}
       {filter}
       {information}
-      <div className="relative flex w-full justify-center gap-6">
+      <div className="relative flex w-full justify-center gap-6 [&>:first-child]:min-w-0">
         {reviews}
         <div className="sticky top-24 hidden h-fit max-w-min flex-col items-start gap-6 text-nowrap lg:flex">
           <CtaButton

--- a/src/app/(school)/bidding/analytics/page.tsx
+++ b/src/app/(school)/bidding/analytics/page.tsx
@@ -162,7 +162,10 @@ export default async function BiddingHistoryPage({
   }
 
   return (
-    <div className="flex w-full max-w-5xl flex-col gap-6 pt-2">
+    <div
+      className="flex w-full max-w-5xl flex-col gap-6 pt-2"
+      data-test="bid-analytics-content"
+    >
       {/* Class Info Summary Card — server rendered */}
       {classInfo && (
         <Card>
@@ -194,7 +197,7 @@ export default async function BiddingHistoryPage({
             {(classInfo.classTimings.length > 0 ||
               classInfo.classExamTimings.some((t) => t.date)) && (
               <>
-                <div className="text-sm">
+                <div className="overflow-x-auto text-sm">
                   <table className="w-full text-xs">
                     <thead>
                       <tr className="text-muted-foreground border-b">

--- a/src/app/(school)/bidding/layout.tsx
+++ b/src/app/(school)/bidding/layout.tsx
@@ -1,6 +1,5 @@
 import { type ReactNode } from "react";
 
-import { ConstrainedContainer } from "@/common/components/constrained-container";
 import { CtaButton } from "@/common/components/cta-button";
 import { EditIcon, GithubIcon, PlusIcon } from "@/common/components/icons";
 import { env } from "@/env";
@@ -9,7 +8,12 @@ import { ReviewCtaButtons } from "@/modules/bidding/components/ReviewCtaButtons"
 
 export default function BidLayout({ children }: { children: ReactNode }) {
   return (
-    <ConstrainedContainer className="relative flex w-full justify-center gap-6">
+    // No ConstrainedContainer: the content column plus the CTA rail never fitted
+    // its 954px cap. min-w-0 lets the content column shrink — the rail is sized
+    // to its own content (`max-w-min` + `text-nowrap`) and never will, so without
+    // it the row overflows and `justify-center` spills half of that off-canvas
+    // to the left, under the fixed sidebar (afterclass-io#545).
+    <div className="relative flex w-full justify-center gap-6 md:px-8 [&>:first-child]:min-w-0">
       {children}
       <div className="sticky top-24 hidden h-fit max-w-min flex-col items-start gap-6 text-nowrap lg:flex">
         <CtaButton
@@ -34,6 +38,6 @@ export default function BidLayout({ children }: { children: ReactNode }) {
         <ReviewCtaButtons />
         <BidWindowScheduleCard />
       </div>
-    </ConstrainedContainer>
+    </div>
   );
 }

--- a/src/app/(school)/layout.tsx
+++ b/src/app/(school)/layout.tsx
@@ -2,6 +2,6 @@ import { type PropsWithChildren } from "react";
 
 export default async function SchoolLayout({ children }: PropsWithChildren) {
   // Full-width shell: pages that need the classic 954px centered column
-  // (reviews, bidding, search, submit) opt back in via ConstrainedContainer.
+  // (reviews, search, submit) opt back in via ConstrainedContainer.
   return <div className="my-1 w-full p-2 md:my-4 md:px-4">{children}</div>;
 }

--- a/src/common/components/constrained-container.tsx
+++ b/src/common/components/constrained-container.tsx
@@ -7,7 +7,8 @@ export type ConstrainedContainerProps = ComponentPropsWithoutRef<"div">;
 /**
  * Re-applies the classic 954px centered content column that used to live in
  * the (school) layout. Used by routes that should stay narrow (reviews,
- * bidding, search, submit) now that the (school) layout is full-width.
+ * search, submit) now that the (school) layout is full-width. Bidding opted
+ * back out — its content column plus CTA rail never fitted 954px.
  */
 export const ConstrainedContainer = ({
   className,

--- a/src/common/components/core-layout.tsx
+++ b/src/common/components/core-layout.tsx
@@ -11,7 +11,7 @@ export async function CoreLayout({ children }: CoreLayoutProps) {
   return (
     <SidebarProvider>
       <AppSidebar />
-      <SidebarInset>
+      <SidebarInset className="min-w-0">
         <CoreLayoutHeader />
         <div id="scroll-to-top"></div>
         <div className="flex flex-1 flex-col">{children}</div>


### PR DESCRIPTION
closes #545

## Context

On the Bid Analytics page the course header card and Historical Bidding Trend card were clipped on the left while the sidebar was expanded — "Negotiating in Management and Business" rendered as "egotiating…".

The content was not being *overlaid*. The bidding layout puts the content column next to a CTA rail that is sized to its own content (`max-w-min` + `text-nowrap`) and so never shrinks. The content column is a flex item with `min-width: auto`, so it could not shrink below its min-content either. The row therefore overflowed its 954px `ConstrainedContainer`, and because the row is `justify-center`, **half that overflow spilled to the left** — to a negative offset that scrolling cannot reach, directly underneath the `fixed` sidebar. Collapsing the sidebar did not remove the spill; it only removed the thing covering it.

Measured on production at the URL from the issue (viewport 1265px): content left edge `176px` vs sidebar right edge `224px` — 48px permanently hidden.

This is why #546's approach (switching the sidebar to a collapsible icon rail) would not have fixed it — the sidebar was never the thing overflowing.

## Changes

- **`(school)/bidding/layout.tsx`** — `[&>:first-child]:min-w-0` lets the content column shrink, so the row no longer overflows. Drops `ConstrainedContainer`: its 954px cap could never hold the content column plus the rail, and full width with `md:px-8` gives 48px side gutters instead of ~150px of dead space.
- **`(school)/(reviews)/layout.tsx`** — same guard on the identical row. Latent there today, but it is the same structure and the same root cause.
- **`common/components/core-layout.tsx`** — `min-w-0` on `SidebarInset`. Without it a wide page stretches the whole shell past the viewport (measured 117px) instead of fitting inside it.
- **`(school)/bidding/analytics/page.tsx`** — `data-test` hook, and an `overflow-x-auto` wrapper on the meeting-information table so it scrolls rather than spilling out of its card.
- Comments in `constrained-container.tsx` and `(school)/layout.tsx` updated — bidding no longer opts in.

## Implementation Details

The row's min-content is `content column + 24px gap + rail`. At 954px it needed ~1136px, so ~198px overflowed and ~99px of that landed left of x=0.

`min-w-0` removes the automatic minimum size on the flex item so the column can shrink to its share (610px = 954 − 24 − 320). It has to be applied at both levels: on the row's first child, and on `SidebarInset` — otherwise the shell itself is sized by content and grows past the viewport.

The wide element is the Historical Bidding Trend card (718px min-content), not the schedule table (299px). The regression spec gates on the chart mounting for that reason.

## How to Test

```bash
bun run dev
npx cypress run --spec cypress/e2e/6-bidding/analytics-layout.cy.ts
```

Or manually at a viewport ≥1250px (below that the sidebar is an overlay `Sheet`, not a fixed column, and the bug cannot occur): open a Bid Analytics page with the sidebar expanded and confirm no card is clipped on the left and there is no horizontal scrollbar.

Red-before-green, verified locally:

| state | failure |
|---|---|
| unmodified `main` | `page scroll width (1276) must not exceed the viewport (1263)` |
| layout guard removed | `content left edge (211.36) must clear the sidebar (224)` |
| `SidebarInset` guard removed | `page scroll width (1384) must not exceed the viewport (1263)` |

Both assertions pass with the fix applied.

Gutters measured at 1265px viewport, before → after: `154/168px` → `48/48px` sidebar closed, `140/140px` → `48/48px` sidebar open.

No regression on `/bidding`, `/course/[code]` or `/timetable` — all measure identically to before with no overflow. The timetable and roadmap grids keep their own `overflow-x-auto`, so the tighter shell does not clip them.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [x] _(where applicable)_ I have added tests to cover my changes
- [x] _(where applicable)_ I have updated the documentation accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o1ihjn9K9Lhk2Ttz62vLD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layouts across bidding, reviews, and shared application pages.
  * Prevented content from overflowing the viewport when sidebars or action panels are expanded.
  * Added horizontal scrolling for meeting information on narrow screens.
  * Improved sizing behavior so analytics and review content remains visible and usable across screen widths.

* **Tests**
  * Added automated coverage to verify Bid Analytics layout behavior at desktop widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->