### PR TITLE
fix(mcp): serve OAuth discovery metadata at /.well-known

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,16 @@ const config = withSentryConfig(
   {
     reactStrictMode: true,
 
+    // File tracing for the MCP view manifest: withMcpUse() only traces
+    // .mcp-use/build into the /api/mcp function bundle, but the
+    // /.well-known discovery route (src/app/.well-known) primes the same
+    // manifest via createNextHandler — without this its bundle misses the
+    // file and every request 500s with ENOENT. withMcpUse preserves
+    // pre-existing keys when it merges its own entry.
+    outputFileTracingIncludes: {
+      "/.well-known": ["./.mcp-use/build/**/*"],
+    },
+
     /**
      * If you have `experimental: { appDir: true }` set, then you must comment the below `i18n` config
      * out.

--- a/src/app/.well-known/[...slug]/route.test.ts
+++ b/src/app/.well-known/[...slug]/route.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+vi.hoisted(() => {
+  // OAuth-mounted (production-shaped) instance: NODE_ENV=production disables
+  // the dev bypass in src/mcp/server.ts, so the OAuth metadata middleware is
+  // mounted. MCP_URL pins the canonical resource host (mcp-use requires an
+  // origin-only value; the /api/mcp basePath is appended by the library).
+  // Must run before the route import below (instance built at import time).
+  // `as Record<...>` — lib.dom/next-env types NODE_ENV as readonly.
+  (process.env as Record<string, string>).NODE_ENV = "production";
+  (process.env as Record<string, string>).MCP_URL = "http://localhost";
+  (process.env as Record<string, string>).MCP_USE_OAUTH_SUPABASE_URL =
+    "http://localhost:54321";
+});
+
+describe("well-known OAuth discovery route", () => {
+  // NOTE: importing the route constructs a dedicated MCP server instance
+  // (Prisma/tRPC graph, ~4s cold; slower under full-suite CPU contention).
+  it("serves the protected-resource metadata for /api/mcp", async () => {
+    const route = await import("./route");
+    expect(typeof route.GET).toBe("function");
+    expect(typeof route.OPTIONS).toBe("function");
+    expect(route.runtime).toBe("nodejs");
+    const res = await route.GET(
+      new Request(
+        "http://localhost/.well-known/oauth-protected-resource/api/mcp",
+        { headers: { accept: "application/json" } },
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as {
+      resource?: string;
+      authorization_servers?: string[];
+    };
+    expect(body.resource).toBe("http://localhost/api/mcp");
+    expect(body.authorization_servers).toEqual([
+      "http://localhost:54321/auth/v1",
+    ]);
+  }, 30_000);
+});

--- a/src/app/.well-known/[...slug]/route.test.ts
+++ b/src/app/.well-known/[...slug]/route.test.ts
@@ -13,6 +13,12 @@ vi.hoisted(() => {
   // @/env requires NEXTAUTH_SECRET in production (imported transitively
   // via the route's Prisma/tRPC graph); any non-empty value satisfies it.
   (process.env as Record<string, string>).NEXTAUTH_SECRET = "test-secret";
+  // src/server/db.ts throws at import in production without DIRECT_URL
+  // (route → route-server → register → dispatch/rate-limit → budget →
+  // ratelimit → db); the test serves only the OAuth discovery document and
+  // never connects, so any valid URL satisfies the presence check.
+  (process.env as Record<string, string>).DIRECT_URL =
+    "postgresql://user:pass@localhost:5432/db";
   (process.env as Record<string, string>).MCP_URL = "http://localhost";
   (process.env as Record<string, string>).MCP_USE_OAUTH_SUPABASE_URL =
     "http://localhost:54321";

--- a/src/app/.well-known/[...slug]/route.test.ts
+++ b/src/app/.well-known/[...slug]/route.test.ts
@@ -10,6 +10,9 @@ vi.hoisted(() => {
   // Must run before the route import below (instance built at import time).
   // `as Record<...>` — lib.dom/next-env types NODE_ENV as readonly.
   (process.env as Record<string, string>).NODE_ENV = "production";
+  // @/env requires NEXTAUTH_SECRET in production (imported transitively
+  // via the route's Prisma/tRPC graph); any non-empty value satisfies it.
+  (process.env as Record<string, string>).NEXTAUTH_SECRET = "test-secret";
   (process.env as Record<string, string>).MCP_URL = "http://localhost";
   (process.env as Record<string, string>).MCP_USE_OAUTH_SUPABASE_URL =
     "http://localhost:54321";

--- a/src/app/.well-known/[...slug]/route.ts
+++ b/src/app/.well-known/[...slug]/route.ts
@@ -1,0 +1,17 @@
+import { createNextHandler } from "mcp-use/next";
+
+import { buildRouteServer } from "@/mcp/route-server";
+
+export const runtime = "nodejs";
+
+// OAuth discovery for remote MCP clients (RFC 9728): the
+// `/.well-known/oauth-protected-resource/*` document MUST be served from the
+// same origin as the resource server, but the /api/mcp catch-all can only
+// receive requests under /api/mcp. This route forwards `/.well-known/*` to
+// the same mcp-use fetch handler (same instance construction as
+// src/app/api/mcp/[[...path]]/route.ts): its `oauthMetadata` middleware
+// answers the protected-resource document by request pathname, so no
+// hand-maintained metadata copy is needed.
+// eslint-disable-next-line @typescript-eslint/unbound-method -- handlers are this-independent closures, not methods (see src/app/api/mcp/[[...path]]/route.ts)
+export const { GET, POST, DELETE, OPTIONS } =
+  createNextHandler(buildRouteServer());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
     "**/*.tsx",
     "**/*.cjs",
     "**/*.js",
+    // `**` globs skip dot-directories: the OAuth discovery route
+    // (src/app/.well-known, RFC 9728) needs an explicit entry.
+    "src/app/.well-known/**/*.ts",
     ".next/types/**/*.ts",
     "eslint.config.mjs",
     "postcss.config.mjs",


### PR DESCRIPTION
## Context

Gemini Spark rejects the MCP server with 'uses an authentication method that Gemini doesn't support — requires standard OAuth'. Probing showed two discovery failures (RFC 9728): the 401's \esource_metadata\ pointer 404'd because the /api/mcp catch-all can only receive requests under /api/mcp, so \GET /.well-known/oauth-protected-resource/api/mcp\ fell through to Next.js /_not-found.

## Changes

- New route \src/app/.well-known/[...slug]/route.ts\: forwards /.well-known/* through \createNextHandler(buildRouteServer())\ — the same instance construction as the /api/mcp route — so mcp-use's oauthMetadata middleware answers the protected-resource document by request pathname. No hand-maintained metadata copy.
- New colocated test pinning 200 + JSON shape (\esource\, \uthorization_servers\) in production-OAuth mode.
- \	sconfig.json\: one explicit include for \src/app/.well-known/**/*.ts\ — \**\ globs skip dot-directories, leaving the route invisible to typecheck/eslint.

## Implementation Details

- Deliberately mirrors \src/app/api/mcp/[[...path]]/route.ts\ (same handler factory, same lint-disable convention); no \maxDuration\ since metadata responses run no tool chains.
- Verified behaviorally in-process: real MCPServer + real oauthSupabaseProvider answers the PRM and authorization-server metadata at the .well-known paths (200 + JSON).
- Does NOT fix the cross-host \esource_metadata\ mismatch (preview advertises the prod origin via MCP_URL) — that needs per-environment MCP_URL, tracked as deploy config, not code.

## How to Test

- \un run mcp:build\ then \un run test:coverage\ (CI runs the new \src/app/.well-known\ test in the unit project).
- After Vercel preview deploys: \curl -i https://<preview>/.well-known/oauth-protected-resource/api/mcp\ → 200 JSON; confirm \esource\ matches the host pasted into Gemini; retry the Gemini custom-app link.

## Checklist

- [x] I have tested the changes (tsc/eslint/prettier green; vitest blocked in local sandbox — runs in CI)
- [x] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly (deploy note: per-env MCP_URL still required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth protected-resource discovery support through a well-known route.
  * Added handling for GET, POST, DELETE, and OPTIONS requests.
  * Configured the route to run in the Node.js runtime.

* **Tests**
  * Added automated coverage verifying route availability and OAuth discovery response details.

* **Chores**
  * Updated project source inclusion to ensure the well-known route is recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->