### PR TITLE
fix(mcp): make MCP UI mobile responsive and consistent

### DIFF
--- a/src/app/.well-known/[...slug]/route.test.ts
+++ b/src/app/.well-known/[...slug]/route.test.ts
@@ -26,7 +26,8 @@ vi.hoisted(() => {
 
 describe("well-known OAuth discovery route", () => {
   // NOTE: importing the route constructs a dedicated MCP server instance
-  // (Prisma/tRPC graph, ~4s cold; slower under full-suite CPU contention).
+  // (Prisma/tRPC graph, ~8s cold; far slower under full-suite CPU
+  // contention — observed >30s). The 120s budget keeps this deterministic.
   it("serves the protected-resource metadata for /api/mcp", async () => {
     const route = await import("./route");
     expect(typeof route.GET).toBe("function");
@@ -48,5 +49,5 @@ describe("well-known OAuth discovery route", () => {
     expect(body.authorization_servers).toEqual([
       "http://localhost:54321/auth/v1",
     ]);
-  }, 30_000);
+  }, 120_000);
 });

--- a/src/app/api/mcp/[[...path]]/embedded.test.ts
+++ b/src/app/api/mcp/[[...path]]/embedded.test.ts
@@ -24,10 +24,12 @@ vi.hoisted(() => {
 // auth (buildToolContext), which is exactly the split the fail-closed test
 // pins: OAuth-mounted server + unauthenticated request → Unauthorized
 // envelope (never a throw, never a 500).
+// Cold import costs ~8s solo and far more under full-suite CPU contention
+// (observed >30s hook timeouts), so the hook budget is a generous 120s.
 beforeAll(async () => {
   vi.stubEnv("MCP_DEV_BYPASS", "true");
   await import("./route");
-}, 30_000);
+}, 120_000);
 
 // Embedded route contract: the Next handler serves the MCP protocol
 // without the standalone CLI. Dev bypass resolves the seeded user
@@ -71,7 +73,7 @@ describe("embedded /api/mcp", () => {
     };
     expect(body.result?.tools).toHaveLength(50);
     vi.unstubAllEnvs();
-  }, 30_000);
+  }, 120_000);
 
   it("fail-closed without bypass or token", async () => {
     vi.stubEnv("MCP_DEV_BYPASS", "");
@@ -253,5 +255,5 @@ describe("embedded /api/mcp views", () => {
     }
     vi.unstubAllEnvs();
     // ~15 RPCs + asset GETs; generous budget for full-suite contention.
-  }, 60_000);
+  }, 120_000);
 });

--- a/src/app/api/mcp/[[...path]]/route.test.ts
+++ b/src/app/api/mcp/[[...path]]/route.test.ts
@@ -16,9 +16,11 @@ vi.hoisted(() => {
 
 describe("MCP route exports", () => {
   // NOTE: importing ./route constructs the dedicated /api/mcp server
-  // (Prisma/tRPC graph, ~4s cold; slower under full-suite CPU contention).
-  // The 30s budget keeps this deterministic — a 5s default flakes under
-  // load and the timeout then cascades into the tests below.
+  // (Prisma/tRPC graph, ~8s cold; far slower under full-suite CPU
+  // contention — observed >30s). The 120s budget keeps this deterministic;
+  // a tight budget flakes under load and the timeout then cascades into
+  // the tests below. Tests run sequentially in-file (default sequence)
+  // so the single import cost is paid once.
   it("exposes GET/POST/DELETE/OPTIONS with nodejs runtime and 300s duration", async () => {
     const route = await import("./route");
     expect(typeof route.GET).toBe("function");
@@ -27,7 +29,7 @@ describe("MCP route exports", () => {
     expect(typeof route.OPTIONS).toBe("function");
     expect(route.runtime).toBe("nodejs");
     expect(route.maxDuration).toBe(300);
-  }, 30_000);
+  }, 120_000);
 
   it("OPTIONS returns 204 with MCP CORS headers", async () => {
     const route = await import("./route");

--- a/src/mcp/dispatch.test.ts
+++ b/src/mcp/dispatch.test.ts
@@ -1,6 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 
+// Confirm-gate determinism: dispatch skips the destructive confirm gate
+// under the dev bypass (NODE_ENV=development/unset + MCP_DEV_BYPASS=true),
+// which a local shell may export (e.g. via .env). Pin the test env to
+// NODE_ENV=test with no bypass so the gate always applies — same seeding
+// pattern as src/app/api/mcp/[[...path]]/route.test.ts. Must run before
+// the dispatch import below (isDevBypass() reads env at call time, but
+// the module graph may capture it during import).
+vi.hoisted(() => {
+  // `as Record<...>` — lib.dom/next-env types NODE_ENV as readonly.
+  (process.env as Record<string, string>).NODE_ENV = "test";
+  delete (process.env as Record<string, string | undefined>).MCP_DEV_BYPASS;
+});
+
 // `server-only` throws outside a Next.js server bundle — stub as no-op
 // (same as register.test.ts / adapters.test.ts).
 vi.mock("server-only", () => ({}));

--- a/src/mcp/view-tools/get-timetable-calendar-link.test.ts
+++ b/src/mcp/view-tools/get-timetable-calendar-link.test.ts
@@ -1,6 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 
+// Confirm-gate determinism: the adapter's destructive confirm gate is
+// skipped under the dev bypass (NODE_ENV=development/unset +
+// MCP_DEV_BYPASS=true), which a local shell may export (e.g. via .env).
+// Pin NODE_ENV=test with no bypass so the gate always applies — same
+// seeding pattern as src/app/api/mcp/[[...path]]/route.test.ts.
+vi.hoisted(() => {
+  // `as Record<...>` — lib.dom/next-env types NODE_ENV as readonly.
+  (process.env as Record<string, string>).NODE_ENV = "test";
+  delete (process.env as Record<string, string | undefined>).MCP_DEV_BYPASS;
+});
+
 /**
  * Adapter-level tests for get-timetable-calendar-link — the secret-isolation
  * boundary. The catalog tool's viewProps carry bearer-bearing iCal URLs that

--- a/src/modules/assistant/assistant-widget.stories.tsx
+++ b/src/modules/assistant/assistant-widget.stories.tsx
@@ -160,6 +160,8 @@ export const QuotaExhausted: Story = {
         onPointerMove: () => undefined,
         onPointerUp: () => undefined,
       },
+      expanded: false,
+      toggleExpanded: () => undefined,
     },
   },
 };

--- a/src/modules/assistant/assistant-widget.test.tsx
+++ b/src/modules/assistant/assistant-widget.test.tsx
@@ -98,4 +98,20 @@ describe("AssistantWidget", () => {
     });
     expect(capture).toHaveBeenCalled();
   });
+
+  it("toggles expanded size when the expand button is clicked", () => {
+    renderWidget(true);
+    const dialog = screen.getByRole("dialog", { name: "AfterClass assistant" });
+    const collapsedWidth = dialog.style.width;
+    // jsdom viewport is 1024x768: expanded (640x760) fits, so width grows.
+    fireEvent.click(screen.getByRole("button", { name: "Expand widget" }));
+    expect(dialog.style.width).toBe("640px");
+    expect(
+      screen.getByRole("button", { name: "Restore widget size" }),
+    ).toBeTruthy();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Restore widget size" }),
+    );
+    expect(dialog.style.width).toBe(collapsedWidth);
+  });
 });

--- a/src/modules/assistant/assistant-widget.tsx
+++ b/src/modules/assistant/assistant-widget.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { ArrowUpRightIcon, ChevronDownIcon, XIcon } from "lucide-react";
+import {
+  ArrowUpRightIcon,
+  ChevronDownIcon,
+  Maximize2Icon,
+  Minimize2Icon,
+  XIcon,
+} from "lucide-react";
 import Link from "next/link";
 import { type ReactNode } from "react";
 import { AfterclassIcon } from "@/common/components/icons";
@@ -24,8 +30,14 @@ export function AssistantWidget({
 }) {
   const viewport = useViewport();
   const fallback = useWidgetPosition(viewport);
-  const { position, size, dragHandlers, resizeHandlers } =
-    geometryProp ?? fallback;
+  const {
+    position,
+    size,
+    dragHandlers,
+    resizeHandlers,
+    expanded,
+    toggleExpanded,
+  } = geometryProp ?? fallback;
 
   if (!position) return null;
 
@@ -90,6 +102,19 @@ export function AssistantWidget({
             >
               Open full chat <ArrowUpRightIcon className="size-3" />
             </Link>
+            <button
+              type="button"
+              aria-label={expanded ? "Restore widget size" : "Expand widget"}
+              aria-pressed={expanded}
+              onClick={toggleExpanded}
+              className="hover:bg-muted rounded p-1"
+            >
+              {expanded ? (
+                <Minimize2Icon className="size-4" />
+              ) : (
+                <Maximize2Icon className="size-4" />
+              )}
+            </button>
             <button
               type="button"
               aria-label="Close assistant"

--- a/src/modules/assistant/assistant-widget.tsx
+++ b/src/modules/assistant/assistant-widget.tsx
@@ -10,6 +10,7 @@ import {
 import Link from "next/link";
 import { type ReactNode } from "react";
 import { AfterclassIcon } from "@/common/components/icons";
+import { Button } from "@/common/components/button";
 import { cn } from "@/common/functions/index";
 import { useViewport } from "./use-viewport";
 import { useWidgetPosition } from "./use-widget-position";
@@ -102,27 +103,31 @@ export function AssistantWidget({
             >
               Open full chat <ArrowUpRightIcon className="size-3" />
             </Link>
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="icon"
               aria-label={expanded ? "Restore widget size" : "Expand widget"}
               aria-pressed={expanded}
               onClick={toggleExpanded}
-              className="hover:bg-muted rounded p-1"
+              className="size-7"
             >
               {expanded ? (
                 <Minimize2Icon className="size-4" />
               ) : (
                 <Maximize2Icon className="size-4" />
               )}
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
+              variant="ghost"
+              size="icon"
               aria-label="Close assistant"
               onClick={() => onOpenChange(false)}
-              className="hover:bg-muted rounded p-1"
+              className="size-7"
             >
               <XIcon className="size-4" />
-            </button>
+            </Button>
           </div>
         </div>
 

--- a/src/modules/assistant/assistant-widget.tsx
+++ b/src/modules/assistant/assistant-widget.tsx
@@ -58,7 +58,7 @@ export function AssistantWidget({
         role="dialog"
         aria-label="AfterClass assistant"
         className={cn(
-          "bg-popover text-popover-foreground fixed z-50 flex flex-col overflow-hidden rounded-2xl border shadow-2xl",
+          "bg-popover text-popover-foreground fixed z-50 flex max-h-[calc(100dvh-1rem)] max-w-[calc(100vw-1rem)] flex-col overflow-hidden rounded-2xl border shadow-2xl",
           !open && "hidden",
         )}
         style={{
@@ -66,6 +66,8 @@ export function AssistantWidget({
           top: boxPos.y,
           width: size.width,
           height: size.height,
+          maxWidth: "calc(100vw - 16px)",
+          maxHeight: "calc(100dvh - 16px)",
         }}
       >
         {/* Drag header - Chatwoot-style: logo + title + open-full-chat + close */}
@@ -104,7 +106,7 @@ export function AssistantWidget({
         <div
           aria-hidden
           {...resizeHandlers}
-          className="absolute right-0 bottom-0 size-5 cursor-se-resize"
+          className="absolute right-0 bottom-0 hidden size-5 cursor-se-resize sm:block"
           style={{ touchAction: "none" }}
         />
       </div>

--- a/src/modules/assistant/chat-page.tsx
+++ b/src/modules/assistant/chat-page.tsx
@@ -6,6 +6,7 @@ import { DefaultChatTransport } from "ai";
 
 import type { AssistantStatus } from "@/server/assistant/status";
 import { MessageList } from "@/modules/assistant/message-list";
+import { TypingIndicator } from "@/modules/assistant/typing-indicator";
 import {
   AssistantErrorMessage,
   shouldShowChatError,
@@ -177,6 +178,7 @@ export function ChatPage({
               {showError && (
                 <AssistantErrorMessage error={chat.error} onRetry={retry} />
               )}
+              {chat.status === "submitted" && <TypingIndicator />}
             </div>
             {consented ? (
               <>

--- a/src/modules/assistant/chat-page.tsx
+++ b/src/modules/assistant/chat-page.tsx
@@ -134,8 +134,8 @@ export function ChatPage({
     // Vertical chrome above the chat (see CoreLayoutHeader h-16 + (school)/layout
     // margins/padding): 5.5rem on mobile, 7rem on desktop. This keeps the composer
     // above the fold at 100% zoom. Update if the header/layout heights change.
-    <div className="mx-auto flex h-[calc(100dvh-5.5rem)] max-w-6xl gap-4 md:h-[calc(100dvh-7rem)]">
-      <aside className="border-border/60 dark:border-muted-foreground/15 flex w-72 shrink-0 flex-col gap-3 rounded-xl border p-3">
+    <div className="mx-auto flex h-[calc(100dvh-5.5rem)] max-w-6xl flex-col gap-4 overflow-y-auto md:h-[calc(100dvh-7rem)] md:flex-row md:overflow-visible">
+      <aside className="border-border/60 dark:border-muted-foreground/15 flex w-full min-w-0 shrink-0 flex-col gap-3 rounded-xl border p-3 md:w-72">
         <McpRecommendation
           hasConnectedAgent={status.hasConnectedAgent}
           onDismiss={() => undefined}
@@ -152,7 +152,7 @@ export function ChatPage({
           onNew={newChat}
         />
       </aside>
-      <main className="border-border/60 dark:border-muted-foreground/15 flex min-w-0 flex-1 flex-col overflow-hidden rounded-xl border">
+      <main className="border-border/60 dark:border-muted-foreground/15 flex min-h-[60dvh] min-w-0 flex-1 flex-col overflow-hidden rounded-xl border md:min-h-0">
         {gate ? (
           <div className="flex h-full items-center justify-center">
             <ConnectGate reason={gate} />

--- a/src/modules/assistant/chat-page.tsx
+++ b/src/modules/assistant/chat-page.tsx
@@ -172,7 +172,7 @@ export function ChatPage({
                   )}
                 </div>
               ) : (
-                <MessageList messages={chat.messages} />
+                <MessageList messages={chat.messages} isStreaming={isRunning} />
               )}
               {showError && (
                 <AssistantErrorMessage error={chat.error} onRetry={retry} />

--- a/src/modules/assistant/chat-panel.tsx
+++ b/src/modules/assistant/chat-panel.tsx
@@ -157,7 +157,7 @@ function ChatPanelInner({
         )}
         {!hasMessages ? (
           <div className="flex h-full flex-col items-center justify-center gap-4 px-4">
-            <h1 className="text-2xl font-semibold">
+            <h1 className="text-center text-xl font-semibold sm:text-2xl">
               How can I help you today?
             </h1>
             {aiConsented && (

--- a/src/modules/assistant/chat-panel.tsx
+++ b/src/modules/assistant/chat-panel.tsx
@@ -167,7 +167,12 @@ function ChatPanelInner({
             )}
           </div>
         ) : (
-          <MessageList messages={chat.messages} />
+          <MessageList
+            messages={chat.messages}
+            isStreaming={
+              chat.status === "streaming" || chat.status === "submitted"
+            }
+          />
         )}
         {showError && (
           <AssistantErrorMessage error={chat.error} onRetry={retry} />

--- a/src/modules/assistant/composer.tsx
+++ b/src/modules/assistant/composer.tsx
@@ -24,7 +24,7 @@ export function Composer({ sendMessage, status, stop }: ComposerProps) {
   return (
     <form
       onSubmit={submit}
-      className="relative flex items-end gap-2 px-3 pt-2 pb-3 shadow-[0px_-20px_20px_1px_rgba(0,0,0,0.05)] dark:shadow-none"
+      className="relative flex max-w-full items-end gap-2 px-3 pt-2 pb-3 shadow-[0px_-20px_20px_1px_rgba(0,0,0,0.05)] dark:shadow-none"
     >
       <textarea
         value={input}
@@ -32,7 +32,7 @@ export function Composer({ sendMessage, status, stop }: ComposerProps) {
         placeholder="Send a message..."
         aria-label="Message input"
         rows={1}
-        className="bg-muted/40 focus:border-ring [field-sizing:content] max-h-32 min-h-10 w-full resize-none rounded-xl border px-3 py-2 text-sm outline-none"
+        className="bg-muted/40 focus:border-ring [field-sizing:content] max-h-32 min-h-10 w-full min-w-0 resize-none rounded-xl border px-3 py-2 text-sm outline-none"
         onKeyDown={(e) => {
           if (e.key === "Enter" && !e.shiftKey) {
             e.preventDefault();
@@ -45,7 +45,7 @@ export function Composer({ sendMessage, status, stop }: ComposerProps) {
           type="button"
           onClick={stop}
           aria-label="Stop generating"
-          className="bg-muted rounded-full p-2.5"
+          className="bg-muted shrink-0 rounded-full p-2.5"
         >
           <SquareIcon className="size-4" />
         </button>
@@ -54,7 +54,7 @@ export function Composer({ sendMessage, status, stop }: ComposerProps) {
           type="submit"
           disabled={!canSend}
           aria-label="Send message"
-          className="bg-primary text-primary-foreground rounded-full p-2.5 disabled:opacity-40"
+          className="bg-primary text-primary-foreground shrink-0 rounded-full p-2.5 disabled:opacity-40"
         >
           <ArrowUpIcon className="size-4" />
         </button>

--- a/src/modules/assistant/error-message.test.tsx
+++ b/src/modules/assistant/error-message.test.tsx
@@ -40,10 +40,10 @@ describe("toFriendlyError", () => {
     );
   });
 
-  it("maps invalid-request (400) to the default message", () => {
+  it("maps invalid-request (400) to a revise-and-resend message", () => {
     expect(
       toFriendlyError(new Error("[POST /api/chat] 400: Invalid request body")),
-    ).toBe(DEFAULT_CHAT_ERROR_MESSAGE);
+    ).toBe("That message could not be sent. Change it and try again.");
   });
 
   it("maps unavailable (503) to a temporarily-unavailable message", () => {

--- a/src/modules/assistant/error-message.test.tsx
+++ b/src/modules/assistant/error-message.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   AssistantErrorMessage,
   DEFAULT_CHAT_ERROR_MESSAGE,
+  isRetryableChatError,
   shouldShowChatError,
   toFriendlyError,
 } from "./error-message";
@@ -15,6 +16,73 @@ describe("toFriendlyError", () => {
     ).toBe(DEFAULT_CHAT_ERROR_MESSAGE);
   });
 
+  it("maps rate-limited (429) to a wait-and-retry message", () => {
+    expect(
+      toFriendlyError(new Error("[POST /api/chat] 429: Rate limit exceeded")),
+    ).toBe("You're sending messages too quickly. Wait a moment and try again.");
+  });
+
+  it("maps turn-in-flight (429 previous turn running) to a wait-for-finish message", () => {
+    expect(
+      toFriendlyError(
+        new Error("[POST /api/chat] 429: A previous turn is still running"),
+      ),
+    ).toBe(
+      "Your previous message is still being answered. Wait for it to finish, then try again.",
+    );
+  });
+
+  it("maps too-large (413) to a shorten-and-resend message", () => {
+    expect(
+      toFriendlyError(new Error("[POST /api/chat] 413: Request too large")),
+    ).toBe(
+      "That message is too large to send. Try shortening it and send again.",
+    );
+  });
+
+  it("maps invalid-request (400) to the default message", () => {
+    expect(
+      toFriendlyError(new Error("[POST /api/chat] 400: Invalid request body")),
+    ).toBe(DEFAULT_CHAT_ERROR_MESSAGE);
+  });
+
+  it("maps unavailable (503) to a temporarily-unavailable message", () => {
+    expect(
+      toFriendlyError(new Error("[POST /api/chat] 503: Assistant unavailable")),
+    ).toBe(
+      "The assistant is temporarily unavailable. Please try again in a bit.",
+    );
+  });
+
+  it("maps 500 Assistant unavailable (sync failure after reservation) to unavailable copy", () => {
+    expect(
+      toFriendlyError(new Error("[POST /api/chat] 500: Assistant unavailable")),
+    ).toBe(
+      "The assistant is temporarily unavailable. Please try again in a bit.",
+    );
+  });
+
+  it("maps disabled (503 kill-switch) to the same copy as unavailable", () => {
+    expect(
+      toFriendlyError(new Error("[POST /api/chat] 503: Assistant disabled")),
+    ).toBe(
+      "The assistant is temporarily unavailable. Please try again in a bit.",
+    );
+  });
+
+  it("maps unauthorized (401) to a signed-out message", () => {
+    expect(
+      toFriendlyError(new Error("[POST /api/chat] 401: Unauthorized")),
+    ).toBe("You were signed out. Sign in again and retry.");
+  });
+
+  it("maps network / unknown failures to the default message", () => {
+    expect(toFriendlyError(new Error("Network request failed"))).toBe(
+      DEFAULT_CHAT_ERROR_MESSAGE,
+    );
+    expect(toFriendlyError(new Error("boom"))).toBe(DEFAULT_CHAT_ERROR_MESSAGE);
+  });
+
   it("never echoes raw error text that may contain internals", () => {
     const raw = "POST /api/chat 500: db connection refused at 10.0.0.5:5432";
     const out = toFriendlyError(new Error(raw));
@@ -24,6 +92,53 @@ describe("toFriendlyError", () => {
 
   it("falls back to the friendly message when there is no error object", () => {
     expect(toFriendlyError(undefined)).toBe(DEFAULT_CHAT_ERROR_MESSAGE);
+  });
+});
+
+describe("isRetryableChatError", () => {
+  it("hides retry for too-large, invalid-request, and unauthorized", () => {
+    expect(
+      isRetryableChatError(
+        new Error("[POST /api/chat] 413: Request too large"),
+      ),
+    ).toBe(false);
+    expect(
+      isRetryableChatError(
+        new Error("[POST /api/chat] 400: Invalid request body"),
+      ),
+    ).toBe(false);
+    expect(
+      isRetryableChatError(new Error("[POST /api/chat] 401: Unauthorized")),
+    ).toBe(false);
+  });
+
+  it("keeps retry for rate-limited, turn-in-flight, unavailable, disabled, and failed", () => {
+    expect(
+      isRetryableChatError(
+        new Error("[POST /api/chat] 429: Rate limit exceeded"),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableChatError(
+        new Error("[POST /api/chat] 429: A previous turn is still running"),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableChatError(
+        new Error("[POST /api/chat] 503: Assistant unavailable"),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableChatError(
+        new Error("[POST /api/chat] 503: Assistant disabled"),
+      ),
+    ).toBe(true);
+    expect(
+      isRetryableChatError(new Error("[POST /api/chat] 500: upstream failure")),
+    ).toBe(true);
+    expect(isRetryableChatError(new Error("Network request failed"))).toBe(
+      true,
+    );
   });
 });
 
@@ -72,5 +187,48 @@ describe("AssistantErrorMessage", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: /try again/i }));
     expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the rate-limited copy for a 429 rate-limit error", () => {
+    render(
+      <AssistantErrorMessage
+        error={new Error("[POST /api/chat] 429: Rate limit exceeded")}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(
+        "You're sending messages too quickly. Wait a moment and try again.",
+      ),
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: /try again/i })).toBeTruthy();
+  });
+
+  it("hides the Try again button for non-retryable errors (too-large)", () => {
+    render(
+      <AssistantErrorMessage
+        error={new Error("[POST /api/chat] 413: Request too large")}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(
+        "That message is too large to send. Try shortening it and send again.",
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
+  });
+
+  it("hides the Try again button for non-retryable errors (unauthorized)", () => {
+    render(
+      <AssistantErrorMessage
+        error={new Error("[POST /api/chat] 401: Unauthorized")}
+        onRetry={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText("You were signed out. Sign in again and retry."),
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /try again/i })).toBeNull();
   });
 });

--- a/src/modules/assistant/error-message.tsx
+++ b/src/modules/assistant/error-message.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertTriangleIcon, RotateCwIcon } from "lucide-react";
-import { parseGateError } from "./gate";
+import { parseChatError, parseGateError } from "./gate";
 
 /** Fixed friendly copy for a failed assistant turn. Deliberately generic: the
  *  transport error can contain internals (e.g. `[POST /api/chat] 500: ...`),
@@ -9,11 +9,42 @@ import { parseGateError } from "./gate";
 export const DEFAULT_CHAT_ERROR_MESSAGE =
   "Something went wrong while sending your message. Please try again.";
 
+/**
+ * Whether a retry makes sense for a chat error. Retrying a rejected payload
+ * (too-large / invalid-request) or a signed-out session (unauthorized) cannot
+ * succeed without the user changing something first, so the Try again button
+ * is hidden for those classes.
+ */
+export function isRetryableChatError(error: unknown): boolean {
+  const cls = parseChatError(error);
+  return (
+    cls !== "too-large" && cls !== "invalid-request" && cls !== "unauthorized"
+  );
+}
+
 /** Sanitize a chat error into user-safe copy. Gate errors (quota/consent) are
- *  handled by the ConnectGate surface, so any error that reaches this bubble
- *  is an unexpected failure - a friendly generic message is always correct. */
-export function toFriendlyError(_error: unknown): string {
-  return DEFAULT_CHAT_ERROR_MESSAGE;
+ *  handled by the ConnectGate surface; anything reaching this bubble maps to
+ *  fixed copy per class — raw error text is never echoed (it can contain
+ *  internals like `[POST /api/chat] 500: ...`). */
+export function toFriendlyError(error: unknown): string {
+  switch (parseChatError(error)) {
+    case "rate-limited":
+      return "You're sending messages too quickly. Wait a moment and try again.";
+    case "turn-in-flight":
+      return "Your previous message is still being answered. Wait for it to finish, then try again.";
+    case "too-large":
+      return "That message is too large to send. Try shortening it and send again.";
+    case "unavailable":
+    case "disabled":
+      return "The assistant is temporarily unavailable. Please try again in a bit.";
+    case "unauthorized":
+      return "You were signed out. Sign in again and retry.";
+    case "invalid-request":
+    case "failed":
+    case null:
+    default:
+      return DEFAULT_CHAT_ERROR_MESSAGE;
+  }
 }
 
 /**
@@ -45,14 +76,16 @@ export function AssistantErrorMessage({
           />
           <span>{toFriendlyError(error)}</span>
         </div>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20 mt-2 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
-        >
-          <RotateCwIcon className="size-3.5" aria-hidden="true" />
-          Try again
-        </button>
+        {isRetryableChatError(error) && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20 mt-2 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
+          >
+            <RotateCwIcon className="size-3.5" aria-hidden="true" />
+            Try again
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/modules/assistant/error-message.tsx
+++ b/src/modules/assistant/error-message.tsx
@@ -41,6 +41,7 @@ export function toFriendlyError(error: unknown): string {
     case "unauthorized":
       return "You were signed out. Sign in again and retry.";
     case "invalid-request":
+      return "That message could not be sent. Change it and try again.";
     case "failed":
     case null:
     default:

--- a/src/modules/assistant/error-message.tsx
+++ b/src/modules/assistant/error-message.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AlertTriangleIcon, RotateCwIcon } from "lucide-react";
+import { Button } from "@/common/components/button";
 import { parseChatError, parseGateError } from "./gate";
 
 /** Fixed friendly copy for a failed assistant turn. Deliberately generic: the
@@ -77,14 +78,16 @@ export function AssistantErrorMessage({
           <span>{toFriendlyError(error)}</span>
         </div>
         {isRetryableChatError(error) && (
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="sm"
             onClick={onRetry}
-            className="border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20 mt-2 inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors"
+            className="border-destructive/40 bg-destructive/10 text-destructive hover:bg-destructive/20 hover:text-destructive mt-2 h-7 text-xs"
           >
             <RotateCwIcon className="size-3.5" aria-hidden="true" />
             Try again
-          </button>
+          </Button>
         )}
       </div>
     </div>

--- a/src/modules/assistant/expandable-card.tsx
+++ b/src/modules/assistant/expandable-card.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ChevronDownIcon } from "lucide-react";
+
+/**
+ * Shared expandable mini-card shell for assistant thread accessories
+ * (reasoning, tool calls). Native <details>/<summary> gives toggle,
+ * keyboard, and aria-expanded semantics with zero JS state — the `open`
+ * prop only seeds initial state; the browser owns it afterwards.
+ */
+export function ExpandableCard({
+  open = false,
+  summary,
+  children,
+}: {
+  open?: boolean;
+  summary: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <details
+      open={open}
+      className="border-border/60 bg-muted/30 group w-full max-w-full min-w-0 overflow-hidden rounded-xl border text-xs [&_summary::-webkit-details-marker]:hidden"
+    >
+      <summary className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left [&::marker]:hidden">
+        {summary}
+        <ChevronDownIcon className="text-muted-foreground size-3.5 shrink-0 transition-transform group-open:rotate-180" />
+      </summary>
+      <div className="border-border/60 border-t px-3 py-2">{children}</div>
+    </details>
+  );
+}

--- a/src/modules/assistant/gate.test.ts
+++ b/src/modules/assistant/gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseGateError } from "./gate";
+import { parseChatError, parseGateError } from "./gate";
 
 describe("parseGateError", () => {
   it("parses quota from an AI SDK APIError message", () => {
@@ -16,5 +16,79 @@ describe("parseGateError", () => {
     expect(parseGateError(new Error("Network request failed"))).toBeNull();
     expect(parseGateError(null)).toBeNull();
     expect(parseGateError(undefined)).toBeNull();
+  });
+});
+
+describe("parseChatError", () => {
+  it("returns null for quota/consent gates (bubble must not show)", () => {
+    expect(
+      parseChatError(new Error('[POST /api/chat] 403: {"gate":"quota"}')),
+    ).toBeNull();
+    expect(
+      parseChatError(new Error('[POST /api/chat] 403: {"gate":"consent"}')),
+    ).toBeNull();
+  });
+
+  it("classifies rate-limited (429 Rate limit exceeded)", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 429: Rate limit exceeded")),
+    ).toBe("rate-limited");
+  });
+
+  it("classifies turn-in-flight (429 previous turn still running)", () => {
+    expect(
+      parseChatError(
+        new Error("[POST /api/chat] 429: A previous turn is still running"),
+      ),
+    ).toBe("turn-in-flight");
+  });
+
+  it("classifies too-large (413 Request too large)", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 413: Request too large")),
+    ).toBe("too-large");
+  });
+
+  it("classifies invalid-request (400 Invalid request body)", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 400: Invalid request body")),
+    ).toBe("invalid-request");
+  });
+
+  it("classifies unavailable (503 Assistant unavailable)", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 503: Assistant unavailable")),
+    ).toBe("unavailable");
+  });
+
+  it("classifies unavailable for 500 Assistant unavailable (sync failure after reservation)", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 500: Assistant unavailable")),
+    ).toBe("unavailable");
+  });
+
+  it("classifies disabled (503 Assistant disabled kill-switch)", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 503: Assistant disabled")),
+    ).toBe("disabled");
+  });
+
+  it("classifies unauthorized (401 Unauthorized)", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 401: Unauthorized")),
+    ).toBe("unauthorized");
+  });
+
+  it("classifies generic 500 / network / unknown as failed", () => {
+    expect(
+      parseChatError(new Error("[POST /api/chat] 500: upstream failure")),
+    ).toBe("failed");
+    expect(parseChatError(new Error("Network request failed"))).toBe("failed");
+    expect(parseChatError(new Error("boom"))).toBe("failed");
+  });
+
+  it("returns null when there is no error", () => {
+    expect(parseChatError(null)).toBeNull();
+    expect(parseChatError(undefined)).toBeNull();
   });
 });

--- a/src/modules/assistant/gate.ts
+++ b/src/modules/assistant/gate.ts
@@ -1,9 +1,69 @@
 export type ChatGate = "quota" | "consent";
 
+/** Closed classification of chat transport failures for the error bubble.
+ *  `null` means "no error bubble" (no error, or a quota/consent gate that
+ *  routes to the ConnectGate surface instead). */
+export type ChatErrorClass =
+  | "rate-limited"
+  | "turn-in-flight"
+  | "too-large"
+  | "invalid-request"
+  | "unavailable"
+  | "disabled"
+  | "unauthorized"
+  | "failed";
+
 /** The transport wraps non-2xx responses in an Error whose message contains the body
  * (e.g. `[POST /api/chat] 403: {"gate":"quota"}`). Scan for the gate field anywhere. */
 export function parseGateError(error: unknown): ChatGate | null {
   if (!(error instanceof Error)) return null;
   const match = /"gate"\s*:\s*"(quota|consent)"/.exec(error.message);
   return match ? (match[1] as ChatGate) : null;
+}
+
+/**
+ * Classify a chat transport error into a user-facing bucket. Gate JSON
+ * (`"gate":"quota"|"consent"`) takes precedence and returns null so the
+ * error bubble never shows for gate errors. Otherwise the HTTP status code
+ * is parsed from the transport message (`/ (\d{3}):/` after the method
+ * prefix) plus case-insensitive body snippet matching.
+ */
+export function parseChatError(error: unknown): ChatErrorClass | null {
+  if (error == null) return null;
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : null;
+  if (message == null) return "failed";
+  // Gate JSON takes precedence — bubble must not show.
+  if (/"gate"\s*:\s*"(quota|consent)"/.test(message)) return null;
+  const lower = message.toLowerCase();
+  const statusMatch = / (\d{3}):/.exec(message);
+  const status = statusMatch ? statusMatch[1] : null;
+
+  if (lower.includes("a previous turn is still running"))
+    return "turn-in-flight";
+  if (lower.includes("rate limit exceeded")) return "rate-limited";
+  if (lower.includes("request too large")) return "too-large";
+  if (lower.includes("invalid request body")) return "invalid-request";
+  if (lower.includes("assistant disabled")) return "disabled";
+  if (lower.includes("assistant unavailable")) return "unavailable";
+  if (lower.includes("unauthorized")) return "unauthorized";
+
+  switch (status) {
+    case "429":
+      return "rate-limited";
+    case "413":
+      return "too-large";
+    case "400":
+      return "invalid-request";
+    case "401":
+      return "unauthorized";
+    case "503":
+      return "unavailable";
+    default:
+      return "failed";
+  }
 }

--- a/src/modules/assistant/mcp-recommendation.tsx
+++ b/src/modules/assistant/mcp-recommendation.tsx
@@ -25,7 +25,7 @@ export function McpRecommendation({
   return (
     <div
       role="status"
-      className="bg-muted/40 flex items-center justify-between gap-3 rounded-xl border px-4 py-3 text-sm"
+      className="bg-muted/40 flex min-w-0 flex-col gap-3 rounded-xl border px-4 py-3 text-sm sm:flex-row sm:items-center sm:justify-between"
       data-umami-event="assistant-mcp-recommendation-shown"
     >
       <p>

--- a/src/modules/assistant/message-list.tsx
+++ b/src/modules/assistant/message-list.tsx
@@ -3,12 +3,22 @@
 import type { UIMessage } from "ai";
 import { Message } from "./message";
 
-export function MessageList({ messages }: { messages: UIMessage[] }) {
+export function MessageList({
+  messages,
+  isStreaming = false,
+}: {
+  messages: UIMessage[];
+  isStreaming?: boolean;
+}) {
   if (!Array.isArray(messages) || messages.length === 0) return null;
   return (
     <div className="flex flex-col gap-4 p-4">
-      {messages.map((m) => (
-        <Message key={m.id} message={m} />
+      {messages.map((m, i) => (
+        <Message
+          key={m.id}
+          message={m}
+          isStreaming={isStreaming && i === messages.length - 1}
+        />
       ))}
     </div>
   );

--- a/src/modules/assistant/message.tsx
+++ b/src/modules/assistant/message.tsx
@@ -2,9 +2,16 @@
 
 import type { UIMessage } from "ai";
 import { Markdown } from "./markdown";
+import { ReasoningCard } from "./reasoning-card";
 import { ToolCallCard, isToolPart } from "./tool-call-card";
 
-export function Message({ message }: { message: UIMessage }) {
+export function Message({
+  message,
+  isStreaming = false,
+}: {
+  message: UIMessage;
+  isStreaming?: boolean;
+}) {
   // Tolerate parts-less messages (persisted/legacy shapes): render as empty.
   const parts = Array.isArray(message.parts) ? message.parts : [];
   if (message.role === "user") {
@@ -29,11 +36,15 @@ export function Message({ message }: { message: UIMessage }) {
         if (part.type === "text") {
           return <Markdown key={i} text={"text" in part ? part.text : ""} />;
         }
-        // Reasoning parts are model-internal deliberation, never user-facing:
-        // drop them (the final text part carries the answer). Rendered once
-        // as raw <pre> before, leaking chain-of-thought into the thread.
+        // Reasoning parts are model-internal deliberation: visible-but-collapsed
+        // by default (never a top-level answer bubble). The final text part
+        // still carries the answer.
         if (part.type === "reasoning") {
-          return null;
+          const text = "text" in part ? part.text : "";
+          if (!text?.trim()) return null;
+          return (
+            <ReasoningCard key={i} text={text} isStreaming={isStreaming} />
+          );
         }
         if (isToolPart(part)) {
           const stepIndex = toolParts.findIndex((t) => t === part) + 1;

--- a/src/modules/assistant/reasoning-card.test.tsx
+++ b/src/modules/assistant/reasoning-card.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ReasoningCard } from "./reasoning-card";
+
+describe("ReasoningCard", () => {
+  it("renders collapsed by default with a Show thinking affordance", () => {
+    render(<ReasoningCard text="let me think step by step" />);
+    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
+    expect(screen.getByText("Show thinking")).toBeDefined();
+    expect(screen.queryByText("let me think step by step")).toBeNull();
+  });
+
+  it("expands on click to reveal text and toggles aria-expanded", () => {
+    render(<ReasoningCard text="let me think step by step" />);
+    fireEvent.click(screen.getByRole("button", { expanded: false }));
+    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    expect(screen.getByText("let me think step by step")).toBeDefined();
+    fireEvent.click(screen.getByRole("button", { expanded: true }));
+    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
+    expect(screen.queryByText("let me think step by step")).toBeNull();
+  });
+
+  it("never renders empty when text is blank or whitespace", () => {
+    const { container: blank } = render(<ReasoningCard text="" />);
+    expect(blank.innerHTML).toBe("");
+    const { container: spaces } = render(<ReasoningCard text={"   \n\t  "} />);
+    expect(spaces.innerHTML).toBe("");
+  });
+
+  it("auto-expands while streaming with a Thinking affordance", () => {
+    render(<ReasoningCard text="streaming thought" isStreaming />);
+    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    expect(screen.getByText(/thinking/i)).toBeDefined();
+    expect(screen.getByText("streaming thought")).toBeDefined();
+  });
+
+  it("collapses back when streaming ends without a user toggle", () => {
+    const { rerender } = render(
+      <ReasoningCard text="streaming thought" isStreaming />,
+    );
+    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    rerender(<ReasoningCard text="streaming thought" isStreaming={false} />);
+    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
+    expect(screen.queryByText("streaming thought")).toBeNull();
+  });
+});

--- a/src/modules/assistant/reasoning-card.test.tsx
+++ b/src/modules/assistant/reasoning-card.test.tsx
@@ -3,22 +3,26 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ReasoningCard } from "./reasoning-card";
 
+// Native <details>/<summary>: jsdom exposes no button role, so assert on
+// the summary affordance + the details open attribute instead.
+function details(): HTMLElement {
+  return document.querySelector("details")!;
+}
+
 describe("ReasoningCard", () => {
   it("renders collapsed by default with a Show thinking affordance", () => {
     render(<ReasoningCard text="let me think step by step" />);
-    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
+    expect(details().hasAttribute("open")).toBe(false);
     expect(screen.getByText("Show thinking")).toBeDefined();
-    expect(screen.queryByText("let me think step by step")).toBeNull();
   });
 
-  it("expands on click to reveal text and toggles aria-expanded", () => {
+  it("reveals text when opened", () => {
     render(<ReasoningCard text="let me think step by step" />);
-    fireEvent.click(screen.getByRole("button", { expanded: false }));
-    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    // jsdom does not toggle <details> on summary click (browser behavior),
+    // so drive the open attribute directly — the content renders inside.
+    details().setAttribute("open", "");
     expect(screen.getByText("let me think step by step")).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { expanded: true }));
-    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
-    expect(screen.queryByText("let me think step by step")).toBeNull();
+    fireEvent.click(screen.getByText("Show thinking"));
   });
 
   it("never renders empty when text is blank or whitespace", () => {
@@ -28,20 +32,18 @@ describe("ReasoningCard", () => {
     expect(spaces.innerHTML).toBe("");
   });
 
-  it("auto-expands while streaming with a Thinking affordance", () => {
+  it("starts open while streaming with a Thinking affordance", () => {
     render(<ReasoningCard text="streaming thought" isStreaming />);
-    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    expect(details().hasAttribute("open")).toBe(true);
     expect(screen.getByText(/thinking/i)).toBeDefined();
-    expect(screen.getByText("streaming thought")).toBeDefined();
   });
 
-  it("collapses back when streaming ends without a user toggle", () => {
+  it("starts collapsed once streaming ends", () => {
     const { rerender } = render(
       <ReasoningCard text="streaming thought" isStreaming />,
     );
-    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    expect(details().hasAttribute("open")).toBe(true);
     rerender(<ReasoningCard text="streaming thought" isStreaming={false} />);
-    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
-    expect(screen.queryByText("streaming thought")).toBeNull();
+    expect(details().hasAttribute("open")).toBe(false);
   });
 });

--- a/src/modules/assistant/reasoning-card.tsx
+++ b/src/modules/assistant/reasoning-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronDownIcon, Loader2Icon } from "lucide-react";
+import { Loader2Icon } from "lucide-react";
 import { cn } from "@/common/functions/index";
+import { ExpandableCard } from "./expandable-card";
 
 export function ReasoningCard({
   text,
@@ -11,49 +11,33 @@ export function ReasoningCard({
   text: string;
   isStreaming?: boolean;
 }) {
-  // User toggle wins once set; otherwise follow the streaming state so the
-  // card auto-expands live and settles collapsed when the turn finishes.
-  const [userToggled, setUserToggled] = useState<boolean | null>(null);
-  const blank = !text?.trim();
-  const open = userToggled ?? isStreaming;
-  if (blank) return null;
+  if (!text?.trim()) return null;
 
   return (
-    <div className="border-border/60 bg-muted/30 w-full max-w-full min-w-0 overflow-hidden rounded-xl border text-xs">
-      <button
-        type="button"
-        onClick={() => setUserToggled(!open)}
-        aria-expanded={open}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left"
-      >
-        {isStreaming && (
-          <Loader2Icon
-            className="text-muted-foreground size-3.5 shrink-0 animate-spin"
-            aria-label="Thinking"
-          />
-        )}
-        <span
-          className={cn(
-            "text-muted-foreground flex-1 truncate font-medium",
-            isStreaming && "animate-pulse",
+    <ExpandableCard
+      open={isStreaming}
+      summary={
+        <>
+          {isStreaming && (
+            <Loader2Icon
+              className="text-muted-foreground size-3.5 shrink-0 animate-spin"
+              aria-label="Thinking"
+            />
           )}
-        >
-          {isStreaming ? "Thinking…" : open ? "Hide thinking" : "Show thinking"}
-        </span>
-        <ChevronDownIcon
-          className={cn(
-            "text-muted-foreground size-3.5 shrink-0 transition-transform",
-            open && "rotate-180",
-          )}
-        />
-      </button>
-      {open && (
-        <div className="border-border/60 border-t px-3 py-2">
-          <pre className="text-muted-foreground max-h-40 overflow-auto text-[11px] break-words whitespace-pre-wrap">
-            {text}
-          </pre>
-        </div>
-      )}
-    </div>
+          <span
+            className={cn(
+              "text-muted-foreground flex-1 truncate font-medium",
+              isStreaming && "animate-pulse",
+            )}
+          >
+            {isStreaming ? "Thinking…" : "Show thinking"}
+          </span>
+        </>
+      }
+    >
+      <pre className="text-muted-foreground max-h-40 overflow-auto text-[11px] break-words whitespace-pre-wrap">
+        {text}
+      </pre>
+    </ExpandableCard>
   );
 }

--- a/src/modules/assistant/reasoning-card.tsx
+++ b/src/modules/assistant/reasoning-card.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronDownIcon, Loader2Icon } from "lucide-react";
+import { cn } from "@/common/functions/index";
+
+export function ReasoningCard({
+  text,
+  isStreaming = false,
+}: {
+  text: string;
+  isStreaming?: boolean;
+}) {
+  // User toggle wins once set; otherwise follow the streaming state so the
+  // card auto-expands live and settles collapsed when the turn finishes.
+  const [userToggled, setUserToggled] = useState<boolean | null>(null);
+  const blank = !text?.trim();
+  const open = userToggled ?? isStreaming;
+  if (blank) return null;
+
+  return (
+    <div className="border-border/60 bg-muted/30 w-full max-w-full min-w-0 overflow-hidden rounded-xl border text-xs">
+      <button
+        type="button"
+        onClick={() => setUserToggled(!open)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left"
+      >
+        {isStreaming && (
+          <Loader2Icon
+            className="text-muted-foreground size-3.5 shrink-0 animate-spin"
+            aria-label="Thinking"
+          />
+        )}
+        <span
+          className={cn(
+            "text-muted-foreground flex-1 truncate font-medium",
+            isStreaming && "animate-pulse",
+          )}
+        >
+          {isStreaming ? "Thinking…" : open ? "Hide thinking" : "Show thinking"}
+        </span>
+        <ChevronDownIcon
+          className={cn(
+            "text-muted-foreground size-3.5 shrink-0 transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </button>
+      {open && (
+        <div className="border-border/60 border-t px-3 py-2">
+          <pre className="text-muted-foreground max-h-40 overflow-auto text-[11px] break-words whitespace-pre-wrap">
+            {text}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/assistant/suggestions.tsx
+++ b/src/modules/assistant/suggestions.tsx
@@ -43,7 +43,7 @@ function SuggestionButton({
     <button
       type="button"
       onClick={() => onPick(suggestion.prompt)}
-      className="hover:bg-muted rounded-full border px-3.5 py-1.5 text-sm transition-colors"
+      className="hover:bg-muted max-w-full rounded-full border px-3 py-1 text-[13px] transition-colors sm:px-3.5 sm:py-1.5 sm:text-sm"
     >
       {suggestion.label}
     </button>
@@ -56,7 +56,7 @@ export function WelcomeSuggestions({
   onPick: (prompt: string) => void;
 }) {
   return (
-    <div className="flex flex-wrap items-center justify-center gap-2 px-4 pb-2">
+    <div className="flex max-w-full flex-wrap items-center justify-center gap-2 px-4 pb-2">
       {WELCOME_SUGGESTIONS.map((s) => (
         <SuggestionButton key={s.prompt} suggestion={s} onPick={onPick} />
       ))}
@@ -94,7 +94,7 @@ export function FollowUpSuggestions({
 }) {
   if (!shouldShowFollowUps(messages, isRunning, lastTurnFailed)) return null;
   return (
-    <div className="flex flex-wrap gap-2 px-4 pb-2">
+    <div className="flex max-w-full flex-wrap gap-2 px-4 pb-2">
       {FOLLOW_UP_SUGGESTIONS.map((s) => (
         <SuggestionButton key={s.prompt} suggestion={s} onPick={onPick} />
       ))}

--- a/src/modules/assistant/tool-call-card.test.tsx
+++ b/src/modules/assistant/tool-call-card.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { ToolCallCard } from "./tool-call-card";
 import type { ToolPart } from "./tool-part";
@@ -19,30 +19,34 @@ const runningPart = {
   input: { query: "IS" },
 } as unknown as ToolPart;
 
+// Native <details>/<summary>: assert on the details open attribute.
+function details(): HTMLElement {
+  return document.querySelector("details")!;
+}
+
 describe("ToolCallCard", () => {
-  it("renders finished calls collapsed with no output visible", () => {
-    const { container } = render(
-      <ToolCallCard part={donePart} stepIndex={1} stepTotal={2} />,
-    );
-    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
-    // Output is rendered via JSON.stringify (with quotes); regex matches the substring.
-    expect(screen.queryByText(/some result text/)).toBeNull();
-    expect(container.querySelector("pre")).toBeNull();
-  });
-
-  it("expands output on header click and collapses on second click", () => {
+  it("renders finished calls collapsed", () => {
     render(<ToolCallCard part={donePart} stepIndex={1} stepTotal={2} />);
-    const header = screen.getByRole("button", { expanded: false });
-    fireEvent.click(header);
-    expect(screen.getByText(/some result text/)).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { expanded: true }));
-    expect(screen.queryByText(/some result text/)).toBeNull();
+    expect(details().hasAttribute("open")).toBe(false);
+    expect(screen.getByText("search-courses")).toBeDefined();
+    expect(screen.getByText("Step 1/2")).toBeDefined();
   });
 
-  it("renders running calls collapsed until clicked", () => {
+  it("renders running calls with a Running indicator", () => {
     render(<ToolCallCard part={runningPart} stepIndex={1} stepTotal={2} />);
-    expect(screen.getByRole("button", { expanded: false })).toBeDefined();
-    fireEvent.click(screen.getByRole("button", { expanded: false }));
-    expect(screen.getByRole("button", { expanded: true })).toBeDefined();
+    expect(details().hasAttribute("open")).toBe(false);
+    expect(screen.getByLabelText("Running")).toBeDefined();
+  });
+
+  it("shows error text for failed calls", () => {
+    const errPart = {
+      type: "tool-search-courses",
+      state: "output-error",
+      toolCallId: "t3",
+      input: { query: "IS" },
+      errorText: "boom failed",
+    } as unknown as ToolPart;
+    render(<ToolCallCard part={errPart} stepIndex={1} stepTotal={1} />);
+    expect(screen.getByLabelText("Error")).toBeDefined();
   });
 });

--- a/src/modules/assistant/tool-call-card.tsx
+++ b/src/modules/assistant/tool-call-card.tsx
@@ -1,10 +1,9 @@
 "use client";
 
-import { CheckIcon, ChevronDownIcon, Loader2Icon, XIcon } from "lucide-react";
-import { useState } from "react";
-import { cn } from "@/common/functions/index";
+import { CheckIcon, Loader2Icon, XIcon } from "lucide-react";
 import { toolLabel, toolStatus, type ToolPart } from "./tool-part";
 import { isToolPart } from "./tool-part";
+import { ExpandableCard } from "./expandable-card";
 
 export { isToolPart };
 export type { ToolPart };
@@ -35,60 +34,47 @@ export function ToolCallCard({
   const input = "input" in part ? part.input : undefined;
   const errorText = "errorText" in part ? part.errorText : undefined;
   const running = status === "running";
-  const [open, setOpen] = useState(false);
 
   return (
-    <div className="border-border/60 bg-muted/30 w-full max-w-[100%] overflow-hidden rounded-xl border text-xs">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="flex w-full items-center gap-2 px-3 py-2 text-left"
-      >
-        {running ? (
-          <Loader2Icon
-            className="text-muted-foreground size-3.5 shrink-0 animate-spin"
-            aria-label="Running"
-          />
-        ) : status === "error" ? (
-          <XIcon
-            className="text-destructive size-3.5 shrink-0"
-            aria-label="Error"
-          />
-        ) : (
-          <CheckIcon
-            className="size-3.5 shrink-0 text-emerald-500"
-            aria-label="Done"
-          />
-        )}
-        <span className="flex-1 truncate font-medium">{label}</span>
-        <span className="text-muted-foreground">
-          Step {stepIndex}/{stepTotal}
-        </span>
-        <ChevronDownIcon
-          className={cn(
-            "text-muted-foreground size-3.5 transition-transform",
-            open && "rotate-180",
+    <ExpandableCard
+      summary={
+        <>
+          {running ? (
+            <Loader2Icon
+              className="text-muted-foreground size-3.5 shrink-0 animate-spin"
+              aria-label="Running"
+            />
+          ) : status === "error" ? (
+            <XIcon
+              className="text-destructive size-3.5 shrink-0"
+              aria-label="Error"
+            />
+          ) : (
+            <CheckIcon
+              className="size-3.5 shrink-0 text-emerald-500"
+              aria-label="Done"
+            />
           )}
-        />
-      </button>
-      {open && (
-        <div className="border-border/60 border-t px-3 py-2">
-          {running && typeof input === "object" && input !== null && (
-            <pre className="text-muted-foreground max-h-40 overflow-auto text-[11px] whitespace-pre-wrap">
-              {formatInput(input)}
-            </pre>
-          )}
-          {!running && "output" in part && part.output !== undefined && (
-            <pre className="max-h-40 overflow-auto text-[11px] whitespace-pre-wrap">
-              {formatInput(part.output)}
-            </pre>
-          )}
-          {status === "error" && errorText && (
-            <p className="text-destructive">{errorText}</p>
-          )}
-        </div>
+          <span className="flex-1 truncate font-medium">{label}</span>
+          <span className="text-muted-foreground">
+            Step {stepIndex}/{stepTotal}
+          </span>
+        </>
+      }
+    >
+      {running && typeof input === "object" && input !== null && (
+        <pre className="text-muted-foreground max-h-40 overflow-auto text-[11px] whitespace-pre-wrap">
+          {formatInput(input)}
+        </pre>
       )}
-    </div>
+      {!running && "output" in part && part.output !== undefined && (
+        <pre className="max-h-40 overflow-auto text-[11px] whitespace-pre-wrap">
+          {formatInput(part.output)}
+        </pre>
+      )}
+      {status === "error" && errorText && (
+        <p className="text-destructive">{errorText}</p>
+      )}
+    </ExpandableCard>
   );
 }

--- a/src/modules/assistant/use-widget-position.test.tsx
+++ b/src/modules/assistant/use-widget-position.test.tsx
@@ -355,3 +355,84 @@ describe("useWidgetPosition drag", () => {
     });
   });
 });
+
+describe("useWidgetPosition expanded persistence", () => {
+  it("persists the expanded flag alongside the expanded size", () => {
+    const { result } = renderHook(() =>
+      useWidgetPosition({ width: 1280, height: 800 }),
+    );
+
+    act(() => {
+      result.current.toggleExpanded();
+    });
+
+    expect(result.current.expanded).toBe(true);
+    expect(result.current.size).toEqual({ width: 640, height: 760 });
+    const stored = JSON.parse(window.localStorage.getItem(STORAGE_KEY)!) as {
+      width: number;
+      height: number;
+      expanded: boolean;
+    };
+    expect(stored.expanded).toBe(true);
+    expect(stored.width).toBe(640);
+    expect(stored.height).toBe(760);
+  });
+
+  it("restores the expanded flag and expanded size from storage", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        right: 16,
+        bottom: 16,
+        width: 640,
+        height: 760,
+        expanded: true,
+      }),
+    );
+
+    const { result } = renderHook(() =>
+      useWidgetPosition({ width: 1280, height: 800 }),
+    );
+
+    expect(result.current.expanded).toBe(true);
+    expect(result.current.size).toEqual({ width: 640, height: 760 });
+  });
+
+  it("restores legacy rows without `expanded` un-expanded (false fallback)", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ right: 16, bottom: 16, width: 640, height: 760 }),
+    );
+
+    const { result } = renderHook(() =>
+      useWidgetPosition({ width: 1280, height: 800 }),
+    );
+
+    expect(result.current.expanded).toBe(false);
+  });
+
+  it("expanded survives a remount and collapse still restores the compact size in-session", () => {
+    const first = renderHook(() =>
+      useWidgetPosition({ width: 1280, height: 800 }),
+    );
+    act(() => {
+      first.result.current.toggleExpanded();
+    });
+    expect(first.result.current.size).toEqual({ width: 640, height: 760 });
+    first.unmount();
+
+    // Fresh mount == reload; storage persists, in-memory prevSizeRef does not.
+    const { result } = renderHook(() =>
+      useWidgetPosition({ width: 1280, height: 800 }),
+    );
+    expect(result.current.expanded).toBe(true);
+    expect(result.current.size).toEqual({ width: 640, height: 760 });
+
+    act(() => {
+      result.current.toggleExpanded();
+    });
+    // Pre-expand size was not persisted, so collapse falls back to DEFAULT_WIDGET_SIZE.
+    expect(result.current.expanded).toBe(false);
+    expect(result.current.size).toEqual({ width: 400, height: 560 });
+  });
+});

--- a/src/modules/assistant/use-widget-position.ts
+++ b/src/modules/assistant/use-widget-position.ts
@@ -25,6 +25,7 @@ type StoredV3 = {
   bottom: number;
   width: number;
   height: number;
+  expanded: boolean;
 };
 
 function loadStored(): StoredV3 | null {
@@ -45,6 +46,8 @@ function loadStored(): StoredV3 | null {
         typeof parsed.height === "number"
           ? parsed.height
           : DEFAULT_WIDGET_SIZE.height,
+      // Rows written before `expanded` existed restore un-expanded.
+      expanded: parsed.expanded === true,
     };
   } catch {
     return null;
@@ -79,7 +82,7 @@ export function useWidgetPosition(viewport: Size) {
   }, [position]);
 
   // Initialise once from storage onto the current viewport; ignore legacy v2 shape.
-  // Legacy rows without `expanded` restore un-expanded (opt-in per click).
+  // Legacy rows without `expanded` restore un-expanded (false fallback).
   useEffect(() => {
     const stored = loadStored();
     if (stored) {
@@ -89,6 +92,7 @@ export function useWidgetPosition(viewport: Size) {
       });
       // eslint-disable-next-line react-hooks/set-state-in-effect -- mount-once localStorage hydration (SSR-unsafe to init lazily); converges, no cascade
       setSize(restoredSize);
+      setExpanded(stored.expanded);
       // Persisted offsets are the user's intended (unclamped) offsets — clamp only for display.
       // fromOffsets will clamp the derived position on-screen; we never overwrite the stored offsets.
       const off: LauncherOffsets = {
@@ -131,12 +135,13 @@ export function useWidgetPosition(viewport: Size) {
         right: offsetsRef.current.right,
         bottom: offsetsRef.current.bottom,
         ...sizeRef.current,
+        expanded,
       };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(toStore));
     } catch {
       // storage unavailable (private mode) - non-fatal
     }
-  }, [position, size]);
+  }, [position, size, expanded]);
 
   // A press records its origin but does NOT capture the pointer. Capture is
   // deferred until the pointer actually moves past DRAG_THRESHOLD, so a plain

--- a/src/modules/assistant/use-widget-position.ts
+++ b/src/modules/assistant/use-widget-position.ts
@@ -7,6 +7,7 @@ import {
   clampSize,
   DEFAULT_WIDGET_SIZE,
   defaultPosition,
+  EXPANDED_WIDGET_SIZE,
   fromOffsets,
   LAUNCHER_SIZE,
   toOffsets,
@@ -59,6 +60,12 @@ export type PointerHandlers = {
 export function useWidgetPosition(viewport: Size) {
   const [size, setSize] = useState<Size>(() => clampSize(DEFAULT_WIDGET_SIZE));
   const [position, setPosition] = useState<Point | null>(null);
+  // Expanded mode (OpenClaw-style): one click toggles between the compact
+  // default size and a larger reading surface. Persisted alongside the size
+  // so a reload keeps the user's preference; the pre-expand size is
+  // remembered in a ref so collapsing restores exactly what was there.
+  const [expanded, setExpanded] = useState(false);
+  const prevSizeRef = useRef<Size | null>(null);
 
   const sizeRef = useRef(size);
   const positionRef = useRef(position);
@@ -72,6 +79,7 @@ export function useWidgetPosition(viewport: Size) {
   }, [position]);
 
   // Initialise once from storage onto the current viewport; ignore legacy v2 shape.
+  // Legacy rows without `expanded` restore un-expanded (opt-in per click).
   useEffect(() => {
     const stored = loadStored();
     if (stored) {
@@ -202,5 +210,40 @@ export function useWidgetPosition(viewport: Size) {
     },
   };
 
-  return { position, size, dragHandlers, resizeHandlers };
+  const toggleExpanded = () => {
+    if (expanded) {
+      // Collapse: restore the exact pre-expand size (or default).
+      setSize(prevSizeRef.current ?? clampSize(DEFAULT_WIDGET_SIZE));
+      prevSizeRef.current = null;
+      setExpanded(false);
+    } else {
+      // Expand: remember the current size, then grow (clamped to viewport).
+      prevSizeRef.current = sizeRef.current;
+      setSize(clampSize(EXPANDED_WIDGET_SIZE, viewport));
+      setExpanded(true);
+    }
+  };
+
+  // Manual resizes while expanded drop back to manual sizing (collapse the
+  // flag without clobbering the user's chosen size).
+  const resizeHandlersWithCollapse: PointerHandlers = {
+    onPointerDown: (e) => {
+      if (expanded) {
+        prevSizeRef.current = null;
+        setExpanded(false);
+      }
+      resizeHandlers.onPointerDown(e);
+    },
+    onPointerMove: resizeHandlers.onPointerMove,
+    onPointerUp: resizeHandlers.onPointerUp,
+  };
+
+  return {
+    position,
+    size,
+    dragHandlers,
+    resizeHandlers: resizeHandlersWithCollapse,
+    expanded,
+    toggleExpanded,
+  };
 }

--- a/src/modules/assistant/widget-geometry.ts
+++ b/src/modules/assistant/widget-geometry.ts
@@ -7,6 +7,10 @@ export const LAUNCHER_SIZE = 56;
 export const MIN_WIDGET_SIZE: Size = { width: 320, height: 420 };
 export const MAX_WIDGET_SIZE: Size = { width: 720, height: 900 };
 export const DEFAULT_WIDGET_SIZE: Size = { width: 400, height: 560 };
+// Expanded mode (OpenClaw-style): a larger reading surface one click away.
+// Capped by clampSize to the viewport, so small screens just get "as big as
+// fits" instead of overflowing.
+export const EXPANDED_WIDGET_SIZE: Size = { width: 640, height: 760 };
 
 export function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);

--- a/src/modules/settings/agents/connect-flow.tsx
+++ b/src/modules/settings/agents/connect-flow.tsx
@@ -56,7 +56,7 @@ const PROVIDERS: Record<
 
 export function ConnectFlow({ mcpUrl }: { mcpUrl: string }) {
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex min-w-0 max-w-full flex-col gap-4">
       <p className="text-muted-foreground text-sm">
         Pick a provider to connect your own AI agent via MCP - unlimited access
         on your own credits.
@@ -73,7 +73,7 @@ function ProviderButtons({ mcpUrl }: { mcpUrl: string }) {
 
   return (
     <>
-      <div className="grid gap-3 sm:grid-cols-3">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
         {(Object.keys(PROVIDERS) as ProviderId[]).map((id) => {
           const active = selected === id;
           return (
@@ -98,7 +98,7 @@ function ProviderButtons({ mcpUrl }: { mcpUrl: string }) {
 
       {/* Expanded detail for the selected provider */}
       {selected && (
-        <div className="bg-muted/40 animate-in fade-in zoom-in-95 rounded-xl border p-4 duration-150">
+        <div className="bg-muted/40 animate-in fade-in zoom-in-95 min-w-0 max-w-full rounded-xl border p-4 duration-150">
           <p className="mb-3 text-sm">{PROVIDERS[selected].description}</p>
 
           {PROVIDERS[selected].oneClickUrl ? (
@@ -107,7 +107,7 @@ function ProviderButtons({ mcpUrl }: { mcpUrl: string }) {
                 href={PROVIDERS[selected].oneClickUrl(mcpUrl)}
                 target="_blank"
                 rel="noreferrer"
-                className="bg-primary text-primary-foreground inline-flex items-center gap-2 rounded-full px-5 py-2 text-sm font-semibold"
+                className="bg-primary text-primary-foreground inline-flex w-full items-center justify-center gap-2 rounded-full px-5 py-2 text-center text-sm font-semibold sm:w-auto"
                 data-umami-event="assistant-connect-oneclick"
               >
                 One-click set up with {PROVIDERS[selected].name}

--- a/src/modules/settings/agents/connect-flow.tsx
+++ b/src/modules/settings/agents/connect-flow.tsx
@@ -56,7 +56,7 @@ const PROVIDERS: Record<
 
 export function ConnectFlow({ mcpUrl }: { mcpUrl: string }) {
   return (
-    <div className="flex min-w-0 max-w-full flex-col gap-4">
+    <div className="flex max-w-full min-w-0 flex-col gap-4">
       <p className="text-muted-foreground text-sm">
         Pick a provider to connect your own AI agent via MCP - unlimited access
         on your own credits.
@@ -98,7 +98,7 @@ function ProviderButtons({ mcpUrl }: { mcpUrl: string }) {
 
       {/* Expanded detail for the selected provider */}
       {selected && (
-        <div className="bg-muted/40 animate-in fade-in zoom-in-95 min-w-0 max-w-full rounded-xl border p-4 duration-150">
+        <div className="bg-muted/40 animate-in fade-in zoom-in-95 max-w-full min-w-0 rounded-xl border p-4 duration-150">
           <p className="mb-3 text-sm">{PROVIDERS[selected].description}</p>
 
           {PROVIDERS[selected].oneClickUrl ? (

--- a/src/modules/settings/agents/connect-page.tsx
+++ b/src/modules/settings/agents/connect-page.tsx
@@ -6,7 +6,7 @@ import { MCPUrlBox } from "./mcp-url-box";
 
 export function ConnectPage({ mcpUrl }: { mcpUrl: string }) {
   return (
-    <div className="flex min-w-0 max-w-full flex-col gap-4">
+    <div className="flex max-w-full min-w-0 flex-col gap-4">
       <div>
         <PageTitle className="text-left text-2xl font-bold tracking-tight md:text-2xl!">
           Connect your own AI agent

--- a/src/modules/settings/agents/connect-page.tsx
+++ b/src/modules/settings/agents/connect-page.tsx
@@ -6,7 +6,7 @@ import { MCPUrlBox } from "./mcp-url-box";
 
 export function ConnectPage({ mcpUrl }: { mcpUrl: string }) {
   return (
-    <div className="flex flex-col gap-4">
+    <div className="flex min-w-0 max-w-full flex-col gap-4">
       <div>
         <PageTitle className="text-left text-2xl font-bold tracking-tight md:text-2xl!">
           Connect your own AI agent

--- a/src/modules/settings/agents/mcp-url-box.tsx
+++ b/src/modules/settings/agents/mcp-url-box.tsx
@@ -36,11 +36,11 @@ export function MCPUrlBox({
   };
 
   return (
-    <div className="mt-3 min-w-0 max-w-full">
+    <div className="mt-3 max-w-full min-w-0">
       <span className="text-sm font-medium">{label}</span>
-      <div className="mt-1.5 flex min-w-0 max-w-full items-center gap-2">
+      <div className="mt-1.5 flex max-w-full min-w-0 items-center gap-2">
         <code
-          className="bg-background min-w-0 max-w-full flex-1 overflow-hidden rounded-md border px-3 py-2 font-mono text-xs break-all"
+          className="bg-background max-w-full min-w-0 flex-1 overflow-hidden rounded-md border px-3 py-2 font-mono text-xs break-all"
           title={mcpUrl}
         >
           {mcpUrl}

--- a/src/modules/settings/agents/mcp-url-box.tsx
+++ b/src/modules/settings/agents/mcp-url-box.tsx
@@ -36,11 +36,11 @@ export function MCPUrlBox({
   };
 
   return (
-    <div className="mt-3">
+    <div className="mt-3 min-w-0 max-w-full">
       <span className="text-sm font-medium">{label}</span>
-      <div className="mt-1.5 flex items-center gap-2">
+      <div className="mt-1.5 flex min-w-0 max-w-full items-center gap-2">
         <code
-          className="bg-background min-w-0 flex-1 rounded-md border px-3 py-2 font-mono text-xs break-all"
+          className="bg-background min-w-0 max-w-full flex-1 overflow-hidden rounded-md border px-3 py-2 font-mono text-xs break-all"
           title={mcpUrl}
         >
           {mcpUrl}


### PR DESCRIPTION
## Context

Assistant UX is inconsistent between surfaces, and MCP-related UI breaks on mobile:
- Sending a message via the widget shows a loading ellipsis, but the full-page `/assistant` chat shows nothing while the request is in flight (`submitted` state).
- MCP connect flow and chat page layout are not mobile responsive.

## Changes

- `chat-page.tsx`: render `TypingIndicator` on `chat.status === "submitted"` to match `chat-panel.tsx` (widget) behavior.
- `chat-page.tsx` layout: stack sidebar above chat on mobile (`flex-col`, full-width aside, `min-h-[60dvh]` main); side-by-side on `md+`.
- `assistant-widget.tsx`: add expand/collapse size toggle (`Maximize2`/`Minimize2`), clamp to viewport (`max-w`, `max-h`), hide resize handle on mobile.
- `tool-call-card.tsx` / `reasoning-card.tsx` / `expandable-card.tsx`: shared details-based expandable card; tool calls use `Button` adoption.
- `error-message.tsx` / `gate.ts`: descriptive chat errors with retry, collapsible reasoning view; consent-403 vs quota gate routing.
- `connect-flow.tsx` / `connect-page.tsx` / `mcp-url-box.tsx`: prettier class ordering, mobile responsive MCP UI.
- Tests: stabilize MCP suite timeouts and dev-bypass env leakage; add/extend `error-message`, `reasoning-card`, `tool-call-card`, `gate`, widget, route/dispatch coverage.

## How to Test

1. Widget: open assistant widget, send a message, confirm loading ellipsis appears while submitted.
2. Full page: go to `/assistant`, send a message, confirm the same loading ellipsis appears (previously showed nothing).
3. Mobile viewport: verify `/assistant` stacks sidebar above chat and MCP connect flow fits without overflow.
4. Widget: toggle expand/restore, drag, and resize (desktop) within viewport bounds.
5. Run `bun run lint`, `bun run test`, `bun run build`.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have tested the changes
- [x] _(where applicable)_ I have added tests to cover my changes
- [ ] _(where applicable)_ I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Assistant widget can expand to a larger view and restore its previous size.
  - Chat now displays typing and reasoning indicators, with expandable thinking and tool details.
  - Error messages provide clearer, situation-specific guidance and show retry controls only when applicable.

- **Bug Fixes**
  - Improved responsive layouts and content truncation across assistant and agent connection interfaces.
  - Increased test timeouts and stabilized environment-dependent test behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->